### PR TITLE
Fix README reference in Sphinx index to correctly include project ove…

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Project AirSim
 
-```{include} ../../README.md
+```{include} ../README.md
 :relative-docs: docs_build/source
 :relative-images: docs_build/source/images
 ```
@@ -9,7 +9,7 @@
 :maxdepth: 2
 :caption: Introduction
 
-README.md
+../README.md
 ```
 
 ```{toctree}
@@ -70,7 +70,6 @@ apis.md
 
 controllers/controllers.md
 controllers/simple_flight.md
-
 controllers/px4/px4.md
 controllers/px4/px4_build.md
 controllers/px4/px4_hitl.md


### PR DESCRIPTION
This PR updates the `index.md` used by the Sphinx documentation system to properly include the `README.md` file as part of the documentation site. Previously, the reference path was incorrect (`../../README.md`), which resulted in the README not being rendered as expected.

Changes include:

* Fixing the relative path in the `{include}` directive to `../README.md`
* Updating the toctree entry under *Introduction* to use the correct path
* Removing an unnecessary blank line in the controllers section for formatting consistency

This ensures that the main project overview is displayed correctly at the top of the generated documentation.
