### PR TITLE
Add support for building both main and Python client Sphinx docs in CI

### DIFF
--- a/.github/workflows/sphinx-docs.yml
+++ b/.github/workflows/sphinx-docs.yml
@@ -19,20 +19,35 @@ jobs:
         with:
           python-version: '3.10'
 
-      - name: Install dependencies
+      - name: Install dependencies for main docs
+        working-directory: ./docs
         run: |
           python -m pip install --upgrade pip
-          pip install -r docs/requirements.txt
+          pip install -r requirements.txt
 
-      - name: Build HTML with Sphinx
+      - name: Install dependencies for Python client docs
+        working-directory: ./client/python/projectairsim/docs
+        run: |
+          pip install -r requirements.txt
+
+      - name: Build Python client docs
+        working-directory: ./client/python/projectairsim/docs
+        run: make html
+
+      - name: Build main docs
         working-directory: ./docs
         run: make html
+
+      - name: Copy Python client docs into main docs
+        run: |
+          mkdir -p docs/build/html/client_api
+          cp -r client/python/projectairsim/docs/build/html/* docs/build/html/client_api/
 
       - name: Deploy to gh_page branch
         if: github.event_name == 'push'
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs/build/html
+          publish_dir: docs/build/html
           publish_branch: gh_page
           force_orphan: true

--- a/client/python/projectairsim/docs/Makefile
+++ b/client/python/projectairsim/docs/Makefile
@@ -6,7 +6,7 @@
 SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = .
-BUILDDIR      = _build
+BUILDDIR      = build
 
 # Put it first so that "make" without argument is like "make help".
 help:

--- a/client/python/projectairsim/docs/conf.py
+++ b/client/python/projectairsim/docs/conf.py
@@ -3,6 +3,8 @@
 # Add projectairsim src/ folder to the Python path for sphinx to find it
 import os
 import sys
+
+import sphinx_rtd_theme
 sys.path.insert(0, os.path.abspath("../src"))
 
 project = 'Project AirSim'
@@ -19,5 +21,5 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'haiku'
-html_static_path = ['_static']
+html_theme = 'sphinx_rtd_theme'
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

<!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
This PR adds support for building both the main Sphinx documentation and the Python client Sphinx documentation in the CI workflow. With these changes, the continuous integration system will automatically build and validate both documentation sets on each commit or pull request, helping to catch documentation issues early.

## How Has This Been Tested?
- Verified that the CI workflow completes successfully and builds both documentation sets without errors.
- Checked the build artifacts to confirm that both main and Python client docs are generated.

## Screenshots and videos (if appropriate):
N/A