### PR TITLE
Fix Python Client API reference link in index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -87,5 +87,5 @@ controllers/px4/px4_sitl_wsl2.md
 :maxdepth: 1
 :caption: Python Client API Reference
 
-Python Client API Reference <https://iamaisim.github.io/ProjectAirSim/api_docs/index.html>
+Python Client API Reference <https://iamaisim.github.io/ProjectAirSim/client_api/index.html>
 ```


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
This PR fixes the broken link to the Python Client API documentation in `docs/index.md`.  
The old link pointed to `/api_docs/`, but the correct path is `/client_api/`.

## How Has This Been Tested?
The documentation was built locally using Sphinx and the updated link was manually verified to correctly redirect to the expected location.

## Screenshots and videos (if appropriate):
N/A