### PR TITLE
Update nng version to v1.11, the lastest stable version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,7 @@ else()
 endif()
 ExternalProject_Add(nng-external
     GIT_REPOSITORY          https://github.com/nanomsg/nng.git
-    GIT_TAG                 v1.5.2
+    GIT_TAG                 v1.11
     GIT_CONFIG              "advice.detachedHead=false"
     PREFIX                  ${CMAKE_BINARY_DIR}/_deps/nng
     # Use Update step override to delete unused /etc/ folder of NNG development support files that list a lot of Go reference packages


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #

## About
This PR updates the NNG dependency used by Project AirSim from version `v1.5.2` to `v1.11`.  
The update is applied via the `ExternalProject_Add(nng-external)` directive in the root `CMakeLists.txt`, ensuring consistent builds with this specific version of the library.

## How Has This Been Tested?
- Performed clean builds on both **Linux** and **Windows**, removing the previous NNG folders (`_deps/nng-*`) to force a fresh clone and build of the specified version.
- Verified that the correct version was used by running:

```bash
  git describe --tags
```

inside `build\_deps\nng\src\nng-external\`, which returned:

```
v1.11
```

* Recompiled the entire project on both platforms without issues.
* Loaded a simulation scene and verified that topic-based communication and services relying on NNG performed as expected in both environments.

## Screenshots and videos (if appropriate):

N/A