### PR TITLE
Use pyproject.toml instead of setup.py

### DIFF
--- a/client/python/projectairsim/pyproject.toml
+++ b/client/python/projectairsim/pyproject.toml
@@ -1,0 +1,77 @@
+[build-system]
+requires = ["setuptools>=68", "wheel", "build"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "projectairsim"
+version = "0.1.1"
+description = "Project AirSim client package"
+readme = { file = "README.md", content-type = "text/markdown" }
+requires-python = ">=3.7,<4"
+license = { text = "MIT" }
+authors = [{ name = "IAMAI Simulations" }]
+keywords = ["simulation", "uav", "drone", "airsim", "robotics"]
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "License :: OSI Approved :: MIT License",
+  "Operating System :: OS Independent",
+  "Topic :: Scientific/Engineering :: Artificial Intelligence",
+  "Topic :: Scientific/Engineering :: Visualization"
+]
+
+dependencies = [
+  "pynng>=0.5.0",
+  "msgpack>=1.0.5",
+  "opencv-python>=4.2.0.32",
+  "numpy",
+  "matplotlib",
+  "commentjson>=0.9.0",
+  "jsonschema>=4.4.0",
+  "inputs",
+  "pqdict",
+  "cryptography",
+  "pykml",
+  "junit-xml",
+  "jsonlines",
+  "Shapely",
+  "azure-storage-blob",
+  "open3d==0.16.*"
+]
+
+[project.optional-dependencies]
+autonomy = [
+  "torch>=1.8.0",
+  "torchvision>=0.9.0",
+  "scikit-image>=0.18.1",
+  "Pillow<=8.2.0",
+  "gym==0.18.3",
+  "onnxruntime-gpu",
+  "pydantic",
+  "python-multipart",
+  "fastapi",
+  "uvicorn",
+]
+bonsai = [
+  "microsoft-bonsai-api==0.1.2",
+  "python-dotenv==0.13.0",
+  "bonsai-cli==1.0.8",
+  "msal-extensions==0.1.3",
+]
+datacollection = [
+  "albumentations==1.3.0",
+]
+
+[tool.setuptools]
+# Source layout: packages live under src/
+package-dir = { "" = "src" }
+
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["projectairsim*"]
+
+# Include non-Python data files inside the wheels/sdist.
+[tool.setuptools.package-data]
+# Adjust these globs if your schemas/assets live elsewhere under the package.
+"projectairsim" = ["schema/*.jsonc", "**/schema/*.jsonc"]
+"projectairsim.autonomy.gym_envs" = ["sim_config/*.jsonc", "*.ink"]

--- a/client/python/projectairsim/setup.py
+++ b/client/python/projectairsim/setup.py
@@ -1,72 +1,8 @@
 #!/usr/bin/env python
-# ProjectAirSim python client package
-
 from setuptools import setup
 
-
-setup(
-    name="projectairsim",
-    version="2023.9.15",
-    description="ProjectAirSim client package",
-    long_description="To be populated from a README.md",  # TODO Populate from a README.md
-    package_dir={"": "src"},
-    packages=[
-        "projectairsim",
-        "projectairsim.autonomy",
-        "projectairsim.autonomy.models",
-        "projectairsim.autonomy.models.backbone",
-        "projectairsim.autonomy.gym_envs",
-        "projectairsim.datacollection",
-        "projectairsim.datacollection.augmentation",
-        "projectairsim.datacollection.collection",
-        "projectairsim.datacollection.randomization",
-        "projectairsim.datacollection.trajectory",
-        "projectairsim.datacollection.specs",
-        "projectairsim.datacollection.validation",
-    ],
-    include_package_data=True,
-    package_data={
-        "": ["schema/*.jsonc"],
-        "projectairsim.autonomy.gym_envs": ["sim_config/*.jsonc", "*.ink"],
-    },
-    install_requires=[
-        "pynng>=0.5.0",
-        "msgpack>=1.0.5",
-        "opencv-python>=4.2.0.32",
-        "numpy",
-        "matplotlib",
-        "commentjson>=0.9.0",
-        "jsonschema>=4.4.0",
-        "inputs",
-        "pqdict",
-        "cryptography",
-        "pykml",
-        "junit-xml",
-        "jsonlines",
-        "Shapely",
-        "azure-storage-blob",
-        "open3d==0.16.*"  # LidarDisplay view setting is broken from 0.17.0
-    ],
-    python_requires=">=3.7, <4",
-    extras_require={
-        "autonomy": [
-            "torch>=1.8.0",
-            "torchvision>=0.9.0",
-            "scikit-image>=0.18.1",
-            "Pillow<=8.2.0",  # Required since pip doesn't resolve gym's req ver
-            "gym==0.18.3",
-            "onnxruntime-gpu",
-            "pydantic",
-            "python-multipart",
-            "fastapi",
-            "uvicorn",
-        ],
-        "bonsai": [
-            "microsoft-bonsai-api==0.1.2",
-            "python-dotenv==0.13.0",
-            "bonsai-cli==1.0.8",
-            "msal-extensions==0.1.3",
-        ],
-        "datacollection": ["albumentations==1.3.0"],
-    },
-)
+# Compatibility shim: all metadata is defined in pyproject.toml (PEP 621).
+# Keeping this file allows legacy workflows like:
+#   python setup.py sdist bdist_wheel
+if __name__ == "__main__":
+    setup()


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->
This pull request modernizes the Python packaging for the `projectairsim` client by migrating all package metadata and configuration from the legacy `setup.py` to a new `pyproject.toml` file. This aligns the project with current Python packaging standards (PEP 517/518/621), improves maintainability, and streamlines dependency management. The old `setup.py` is retained only as a minimal compatibility shim.

**Migration to modern Python packaging:**

* Added a comprehensive `pyproject.toml` file that defines build system requirements, project metadata, dependencies (including optional extras), and package data configuration, fully replacing the role of `setup.py`.
* Simplified `setup.py` to a minimal stub that delegates to setuptools, preserving compatibility with legacy build commands but moving all configuration to `pyproject.toml`.

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->

## Screenshots and videos (if appropriate):