### PR TITLE
upgrade UE 5.3

### DIFF
--- a/tools/lvmon/Lib/src/serverconnectiontcp.cpp
+++ b/tools/lvmon/Lib/src/serverconnectiontcp.cpp
@@ -3,6 +3,8 @@
 
 // MIT License. All rights reserved.
 
+#include <cstdarg>
+#include <cstdio>
 #include "serverconnectiontcp.h"
 
 #include <LVMon/lvmonprotocol.h>

--- a/unreal-linux-toolchain.cmake
+++ b/unreal-linux-toolchain.cmake
@@ -19,7 +19,7 @@ set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_PROCESSOR x86_64)
 
 # Set include and link dir paths to UE 4.27's bundled toolchain
-set(UE_TOOLCHAIN "Engine/Extras/ThirdPartyNotUE/SDKs/HostLinux/Linux_x64/v21_clang-15.0.1-centos7")
+set(UE_TOOLCHAIN "Engine/Extras/ThirdPartyNotUE/SDKs/HostLinux/Linux_x64/v22_clang-16.0.6-centos7")
 set(CMAKE_SYSROOT "$ENV{UE_ROOT}/${UE_TOOLCHAIN}/x86_64-unknown-linux-gnu")
 set(CMAKE_C_COMPILER "${CMAKE_SYSROOT}/bin/clang")
 set(CMAKE_CXX_COMPILER "${CMAKE_SYSROOT}/bin/clang++")

--- a/unreal/Blocks/Blocks.uproject
+++ b/unreal/Blocks/Blocks.uproject
@@ -1,6 +1,6 @@
 {
 	"FileVersion": 3,
-	"EngineAssociation": "5.1",
+	"EngineAssociation": "5.3",
 	"Category": "",
 	"Description": "",
 	"Modules": [

--- a/unreal/Blocks/Plugins/ProjectAirSim/Source/ProjectAirSim/Private/LightActorBase.cpp
+++ b/unreal/Blocks/Plugins/ProjectAirSim/Source/ProjectAirSim/Private/LightActorBase.cpp
@@ -4,6 +4,7 @@
 // MIT License. All rights reserved.
 
 #include "LightActorBase.h"
+#include "Components/LocalLightComponent.h"
 
 // Returns true if able to set intensity on all light components
 // False if any item is nullptr
@@ -41,7 +42,7 @@ bool ALightActorBase::SetRadius(float NewRadius) {
   for(int i = 0; i < lightComponents.Num(); i++)
   {
     ULocalLightComponent* localLightComponent =
-        dynamic_cast<ULocalLightComponent*>(lightComponents[i]);
+        Cast<ULocalLightComponent>(lightComponents[i]);
 
     if (localLightComponent != nullptr) {
       localLightComponent->SetAttenuationRadius(NewRadius);

--- a/unreal/Blocks/Plugins/ProjectAirSim/Source/ProjectAirSim/Private/Sensors/LidarIntensitySceneViewExtension.h
+++ b/unreal/Blocks/Plugins/ProjectAirSim/Source/ProjectAirSim/Private/Sensors/LidarIntensitySceneViewExtension.h
@@ -17,9 +17,9 @@ class FLidarIntensitySceneViewExtension : public FSceneViewExtensionBase {
                          FSceneView& InView) override {};
   virtual void BeginRenderViewFamily(FSceneViewFamily& InViewFamily) override {};
   virtual void PreRenderViewFamily_RenderThread(
-      FRHICommandListImmediate& RHICmdList,
+      FRDGBuilder& GraphBuilder,
       FSceneViewFamily& InViewFamily) override {};
-  virtual void PreRenderView_RenderThread(FRHICommandListImmediate& RHICmdList,
+  virtual void PreRenderView_RenderThread(FRDGBuilder& GraphBuilder,
                                           FSceneView& InView) override {};
   virtual void PostRenderBasePass_RenderThread(
       FRHICommandListImmediate& RHICmdList, FSceneView& InView) override {};

--- a/unreal/Blocks/Plugins/ProjectAirSim/Source/ProjectAirSim/Private/Sensors/LidarIntensityShader.h
+++ b/unreal/Blocks/Plugins/ProjectAirSim/Source/ProjectAirSim/Private/Sensors/LidarIntensityShader.h
@@ -2,18 +2,18 @@
 
 #include "CoreMinimal.h"
 #include "UnrealCameraRenderRequest.h"
-#include "Runtime/Engine/Classes/Engine/TextureRenderTarget2D.h"
+#include "Engine/TextureRenderTarget2D.h"
 
 #include "RHI.h"
 #include "RHIStaticStates.h"
-#include "Runtime/RenderCore/Public/ShaderParameterUtils.h"
-#include "Runtime/RenderCore/Public/RenderResource.h"
-#include "Runtime/Renderer/Public/MaterialShader.h"
-#include "Runtime/RenderCore/Public/RenderGraphResources.h"
+#include "ShaderParameterUtils.h"
+#include "RenderResource.h"
+#include "MaterialShader.h"
+#include "RenderGraphResources.h"
 
 // FScreenPassTextureViewportParameters and FScreenPassTextureInput
-#include "Runtime/Renderer/Private/ScreenPass.h"
-#include "Runtime/Renderer/Private/SceneTextureParameters.h"
+#include "ScreenPass.h"
+#include "SceneTextureParameters.h"
 
 BEGIN_SHADER_PARAMETER_STRUCT(FLidarIntensityShaderInputParameters, )
   SHADER_PARAMETER_STRUCT_REF(FViewUniformShaderParameters, View)
@@ -51,9 +51,9 @@ class FLidarIntensityPS : public FLidarIntensityShader {
       const ShaderMetaType::CompiledShaderInitializerType& Initializer)
       : FLidarIntensityShader(Initializer) {}
 
-  void SetParameters(FRHICommandList& RHICmdList, const FSceneView& View) {
+  void SetParameters(FRHIBatchedShaderParameters& BatchedParameters, const FSceneView& View) {
     FGlobalShader::SetParameters<FViewUniformShaderParameters>(
-        RHICmdList, RHICmdList.GetBoundPixelShader(), View.ViewUniformBuffer);
+        BatchedParameters, View.ViewUniformBuffer);
   }
 
   static void ModifyCompilationEnvironment(
@@ -73,8 +73,8 @@ class FLidarIntensityVS : public FLidarIntensityShader {
       const ShaderMetaType::CompiledShaderInitializerType& Initializer)
       : FLidarIntensityShader(Initializer) {}
 
-  void SetParameters(FRHICommandList& RHICmdList, const FSceneView& View) {
+  void SetParameters(FRHIBatchedShaderParameters& BatchedParameters, const FSceneView& View) {
     FGlobalShader::SetParameters<FViewUniformShaderParameters>(
-        RHICmdList, RHICmdList.GetBoundVertexShader(), View.ViewUniformBuffer);
+        BatchedParameters, View.ViewUniformBuffer);
   }
 };

--- a/unreal/Blocks/Plugins/ProjectAirSim/Source/ProjectAirSim/ProjectAirSim.Build.cs
+++ b/unreal/Blocks/Plugins/ProjectAirSim/Source/ProjectAirSim/ProjectAirSim.Build.cs
@@ -3,6 +3,7 @@
 //
 // MIT License. All rights reserved.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using UnrealBuildTool;
@@ -11,18 +12,13 @@ public class ProjectAirSim : ModuleRules
 {
     public ProjectAirSim(ReadOnlyTargetRules Target) : base(Target)
     {
-        CppStandard = CppStandardVersion.Cpp17;
         PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        PrivatePCHHeaderFile = "Public/ProjectAirSim.h";
 
         // Allow Unreal's default setting for IWYU instead of setting explicitly
         // bEnforceIWYU = true;  // UE <= 5.1
         // IWYUSupport = IWYUSupport.None;  // UE 5.2+
 
         bEnableExceptions = true;
-
-        // Silence MSVC 14.25.28610 deprecation warning from Eigen
-        PublicDefinitions.Add("_SILENCE_CXX17_RESULT_OF_DEPRECATION_WARNING");
 
         string buildType = (Target.Configuration == UnrealTargetConfiguration.Debug ||
                             Target.Configuration == UnrealTargetConfiguration.DebugGame)
@@ -47,7 +43,6 @@ public class ProjectAirSim : ModuleRules
         if (Target.Platform == UnrealTargetPlatform.Win64)
         {
             List<string> liststrIncludes = new List<string> {
-                    ModuleDirectory + "/Private",
                     PluginDirectory + "/SimLibs/core_sim/include",
                     PluginDirectory + "/SimLibs/simserver/include",
                     PluginDirectory + "/SimLibs/physics/include",

--- a/unreal/Blocks/Source/Blocks.Target.cs
+++ b/unreal/Blocks/Source/Blocks.Target.cs
@@ -11,7 +11,7 @@ public class BlocksTarget : TargetRules
 	public BlocksTarget(TargetInfo Target) : base(Target)
 	{
 		Type = TargetType.Game;
-		DefaultBuildSettings = BuildSettingsVersion.V2;
+		DefaultBuildSettings = BuildSettingsVersion.V4;
 		IncludeOrderVersion = EngineIncludeOrderVersion.Latest;  // from UE5.1
 		ExtraModuleNames.AddRange(new string[] { "Blocks" });
 

--- a/unreal/Blocks/Source/BlocksEditor.Target.cs
+++ b/unreal/Blocks/Source/BlocksEditor.Target.cs
@@ -11,7 +11,7 @@ public class BlocksEditorTarget : TargetRules
 	public BlocksEditorTarget(TargetInfo Target) : base(Target)
 	{
 		Type = TargetType.Editor;
-		DefaultBuildSettings = BuildSettingsVersion.V2;
+		DefaultBuildSettings = BuildSettingsVersion.V4;
 		IncludeOrderVersion = EngineIncludeOrderVersion.Latest;  // from UE5.1
 		ExtraModuleNames.AddRange(new string[] { "Blocks" });
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->
This pull request updates the Unreal Engine version and toolchain across the project, brings code and build settings in line with newer Unreal standards, and refactors some rendering and actor logic for improved compatibility and maintainability. The most important changes are grouped below:

**Unreal Engine and Toolchain Upgrades**
* Updated the Unreal Engine association in `Blocks.uproject` from 5.1 to 5.3, ensuring the project uses the latest engine features and compatibility.
* Changed the toolchain path in `unreal-linux-toolchain.cmake` to use Clang 16.0.6 (v22) instead of Clang 15.0.1 (v21), aligning with Unreal Engine 5.3 requirements.

**Build System and Configuration Updates**
* Upgraded build settings in `Blocks.Target.cs` and `BlocksEditor.Target.cs` from `BuildSettingsVersion.V2` to `BuildSettingsVersion.V4`, and made related adjustments in `ProjectAirSim.Build.cs` for Unreal 5.3 compatibility. [[1]](diffhunk://#diff-e9d1e39e8444f54831b405a8e51a530a002053273918b379157f0b800521a93dL14-R14) [[2]](diffhunk://#diff-82966f95d34d209f35528d4ecaff9ad60ebf08d5acb6ab496627a6d1f5e8a9f0L14-R14) [[3]](diffhunk://#diff-73321ecaddd1d877bc03e2fcbae1a45ad0b724a584be1b561b6b2b624e729d05L14-L26)
* Removed deprecated or unnecessary build definitions and include paths, such as `_SILENCE_CXX17_RESULT_OF_DEPRECATION_WARNING` and the `Private` include directory for Windows builds.

**Rendering and Shader Refactoring**
* Refactored shader parameter setting in `LidarIntensityShader.h` and its usage in `LidarIntensitySceneViewExtension.cpp` to use `FRHIBatchedShaderParameters` and `GetScratchShaderParameters`, matching new Unreal Engine RHI conventions. [[1]](diffhunk://#diff-1629b84aa645c3d384e6a20d7c403c5ffcffc7753989cafa0822d15fae44a6f3L199-R205) [[2]](diffhunk://#diff-f5fbea85275f6845595ed12722a4f0f970b7aa36456985750a3c0e36935e9ffdL54-R56) [[3]](diffhunk://#diff-f5fbea85275f6845595ed12722a4f0f970b7aa36456985750a3c0e36935e9ffdL76-R78)
* Updated buffer locking/unlocking in `LidarIntensitySceneViewExtension.cpp` to use `RHICmdList.LockBuffer` and `RHICmdList.UnlockBuffer` for improved safety and compatibility.
* Changed header includes to use engine module paths instead of deprecated `Runtime/` paths for shader and rendering classes.

**Actor and Component Improvements**
* Switched from `dynamic_cast` to Unreal's `Cast<>` for type safety and performance when accessing `ULocalLightComponent` in `LightActorBase.cpp`.
* Added missing include for `LocalLightComponent` to ensure proper compilation and usage.

**General Codebase Maintenance**
* Added missing standard library includes (`<cstdarg>` and `<cstdio>`) in `serverconnectiontcp.cpp` for robustness.
* Updated method signatures in `LidarIntensitySceneViewExtension.h` to use `FRDGBuilder` instead of `FRHICommandListImmediate`, reflecting changes in Unreal Engine's rendering pipeline.

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->

## Screenshots and videos (if appropriate):