### PR TITLE
Fix vector instatiation

### DIFF
--- a/vehicle_apis/multirotor_api/src/arducopter_api.cpp
+++ b/vehicle_apis/multirotor_api/src/arducopter_api.cpp
@@ -237,7 +237,7 @@ std::vector<float> ArduCopterApi::GetControlSignals(const std::string& actuator_
   }
 
   // std::lock_guard<std::mutex> guard(hil_controls_mutex_);
-  return std::vector<float>(1,control_outputs_[actuator_map_itr->second]);
+  return std::vector<float>(1, control_outputs_[actuator_map_itr->second]);
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->
This pull request makes a small change to the way control signals are returned in the `ArduCopterApi::GetControlSignals` method. Instead of copying the entire vector, it now returns a vector containing only a single control output value.

- Changed `ArduCopterApi::GetControlSignals` in `arducopter_api.cpp` to return a vector with a single element (the mapped control output), rather than copying the entire vector.

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->

## Screenshots and videos (if appropriate):