### PR TITLE
Example scripts: Fix typo in horz-distortion-contrib key

### DIFF
--- a/client/python/example_user_scripts/sim_config/robot_quadrotor_px4_gimbal.jsonc
+++ b/client/python/example_user_scripts/sim_config/robot_quadrotor_px4_gimbal.jsonc
@@ -426,7 +426,7 @@
           "horz-noise-lines-contrib": 1.0,
           "horz-noise-lines-density-y": 0.01,
           "horz-noise-lines-density-xy": 0.5,
-          "horz-distortion-contirb": 1.0,
+          "horz-distortion-contrib": 1.0,
           "horz-distortion-strength": 0.002
         }
       ],


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #   
This is not associated to an existing issue

## About
This simple PR fixes a key name error which gives problem while spawning the the **scene_px4_gimbal.jsonc**

## How Has This Been Tested?
Yes!
This has been tested with px4

$ make px4_sitl iris_with_gimbal
I load the file **scene_px4_gimbal.jsonc** passed to px4_quadrotor.py as per the docs

## Screenshots and videos (if appropriate):
Not required