### PR TITLE
Inform the user that  the environment variable UE_ROOT is not set

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,4 +4,10 @@
 # MIT License.
 
 set -e
+
+# Inform the user that the environment variable UE_ROOT is not set.
+if [ -z "$UE_ROOT" ]; then
+    echo "Warning: The UE_ROOT environment variable is not set." >&2
+fi
+
 make -f build_linux.mk $1

--- a/setup_linux_dev_tools.sh
+++ b/setup_linux_dev_tools.sh
@@ -5,6 +5,11 @@
 
 set -e
 
+# Inform the user that the environment variable UE_ROOT is not set.
+if [ -z "$UE_ROOT" ]; then
+    echo "Warning: The UE_ROOT environment variable is not set." >&2
+fi
+
 sudo apt-get update
 
 # Install lsb_release to check Ubuntu version


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #105    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->
Inform the user that the environment variable ue_root is not set.

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->
1. The system outputs a message indicating that the UE_ROOT environment variable is not set.
```bash
unset UE_ROOT
bash -x ./setup_linux_dev_tools.sh
bash -x ./build.sh clean
bash -x ./build.sh simlibs_debug
# The program will display a message in the standard output .
```
2. No output.
```bash
export UE_ROOT=/home/carryaimp/apps/Linux_Unreal_Engine_5.2.1
bash -x ./setup_linux_dev_tools.sh

bash -x ./build.sh clean
bash -x ./build.sh simlibs_debug
```

## Screenshots and videos (if appropriate):