### PR TITLE
Fix EnvActor topic name to match C++ implementation

### DIFF
--- a/client/python/projectairsim/src/projectairsim/env_actor.py
+++ b/client/python/projectairsim/src/projectairsim/env_actor.py
@@ -38,6 +38,8 @@ class EnvActor(object):
     def set_actor_info_topics(self):
         self.actor_info = {}
         self.actor_info["actual_kinematics"] = f"{self.parent_topic}/actual_kinematics"
+        # Backward compatibility: keep "actual_pose" as an alias for "actual_kinematics"
+        self.actor_info["actual_pose"] = self.actor_info["actual_kinematics"]
 
     def log_topics(self):
         projectairsim_log().info("-------------------------------------------------")


### PR DESCRIPTION
Changed topic from 'actual_pose' to 'actual_kinematics' in env_actor.py to ensure compatibility with EnvActor::Impl (env_actor.cpp:263).

About
This PR updates the topic name in env_actor.py from 'actual_pose' to 'actual_kinematics' to match the expected topic in the C++ implementation.

How Has This Been Tested?
When the topic was registered as "actual_kinematics", I was able to receive callback calls using actor.actor_info["actual_kinematics"].
When the topic was registered as "actual_pose", I was able to receive callback calls using f"{actor.parent_topic}/actual_kinematics".