### PR TITLE
python: use importlib.resources for schema loading only

### DIFF
--- a/client/python/projectairsim/src/projectairsim/utils.py
+++ b/client/python/projectairsim/src/projectairsim/utils.py
@@ -8,6 +8,7 @@ ProjectAirSim utilities
 import logging
 import math
 from typing import Dict, List, Tuple
+import importlib.resources as resources
 import msgpack
 import numpy as np
 import collections
@@ -17,9 +18,27 @@ import commentjson
 import jsonschema
 from jsonschema import validate
 from pykml import parser
-import pkg_resources
 
 from projectairsim.geodetic_converter import GeodeticConverter
+
+
+def load_text_resource(resource_path: str) -> str:
+    """Loads a package text resource and returns its contents.
+
+    Uses importlib.resources.files() when available (Python >= 3.9).
+    Falls back to pkg_resources for older Python versions.
+    """
+    if hasattr(resources, "files"):
+        # Preferred API: importlib.resources.files() (Python >= 3.9)
+        return (
+            resources.files(__package__)
+            .joinpath(resource_path)
+            .read_text(encoding="utf-8")
+        )
+    # Compatibility fallback for Python < 3.9
+    import pkg_resources
+
+    return pkg_resources.resource_string(__package__, resource_path).decode("utf-8")
 
 
 def get_pitch_between_traj_points(point1, point2):
@@ -485,12 +504,8 @@ def load_scene_config_as_dict(
     total_path = os.path.join(sim_config_path, config_name)
     filepaths = [total_path, [], []]
 
-    robot_config_schema = pkg_resources.resource_string(
-        __name__, "schema/robot_config_schema.jsonc"
-    )
-    scene_config_schema = pkg_resources.resource_string(
-        __name__, "schema/scene_config_schema.jsonc"
-    )
+    robot_config_schema = load_text_resource("schema/robot_config_schema.jsonc")
+    scene_config_schema = load_text_resource("schema/scene_config_schema.jsonc")
 
     with open(total_path) as f:
         data = commentjson.load(f)  # read and write the JSON as a dict

--- a/client/python/projectairsim/tests/test_json_schema.py
+++ b/client/python/projectairsim/tests/test_json_schema.py
@@ -5,6 +5,7 @@ MIT License.
 Tests to validate errors from jsonschema validation
 """
 
+import os
 import time
 
 import pytest
@@ -12,6 +13,7 @@ import jsonschema
 
 from pynng import NNGException
 from projectairsim import Drone, ProjectAirSimClient, World
+from projectairsim.utils import load_scene_config_as_dict
 
 @pytest.fixture(scope="module", autouse=True)
 def client(request):
@@ -33,3 +35,15 @@ def test_robot_type_schema(client):
         world = World(client, 'robot_test_type_schema.jsonc')
 
 
+def test_load_scene_config_respects_caller_sim_config_path():
+    """Regression: sim_config_path provided by the caller must be used verbatim
+    for path resolution of scene and robot config files."""
+    config_name = "scene_test_drone.jsonc"
+    sim_config_path = os.path.join(os.path.dirname(__file__), "sim_config")
+
+    _, filepaths = load_scene_config_as_dict(config_name, sim_config_path)
+
+    assert filepaths[0] == os.path.join(sim_config_path, config_name)
+    assert filepaths[1] == [
+        os.path.join(sim_config_path, "robot_test_quadrotor_fastphysics.jsonc")
+    ]


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->
This pull request refactors how package resources are loaded and improves compatibility across Python versions. It introduces a new utility function for resource loading and updates relevant code to use this function. Additionally, a regression test is added to ensure correct path resolution for configuration files.

**Resource loading improvements:**

* Added a new `load_text_resource` utility function in `utils.py` to load package resources using `importlib.resources.files()` for Python >= 3.9, with a fallback to `pkg_resources` for older versions. This improves compatibility and future-proofs resource access. [[1]](diffhunk://#diff-998291f24d3a33a3b6bf920ab61447d3469862c066b4735f7d76fdf76877a775R11) [[2]](diffhunk://#diff-998291f24d3a33a3b6bf920ab61447d3469862c066b4735f7d76fdf76877a775L20-R43)
* Updated resource loading in `load_scene_config_as_dict` to use the new `load_text_resource` function instead of directly calling `pkg_resources.resource_string`.

**Testing enhancements:**

* Added a regression test `test_load_scene_config_respects_caller_sim_config_path` in `test_json_schema.py` to verify that the `sim_config_path` argument is used verbatim for resolving configuration file paths.
* Updated test imports to include `os` and `load_scene_config_as_dict` for the new test.

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->

## Screenshots and videos (if appropriate):