### PR TITLE
generic vscode script to gen project

### DIFF
--- a/unreal/Blocks/blocks_genprojfiles_vscode.sh
+++ b/unreal/Blocks/blocks_genprojfiles_vscode.sh
@@ -6,26 +6,38 @@
 if [ -z "$UE_ROOT" ]
 then
   echo
-  echo ERROR: UE_ROOT environmant variable is not set. It must be set to the target \
+  echo ERROR: UE_ROOT environment variable is not set. It must be set to the target \
     Unreal engine\'s root folder path, ex. /home/projectairsimuser/UnrealEngine-5.0.3
 else
-  # Generate VS Code UE project files (overwrites .vscode\settings.json)
-  echo Generating VS Code project files with environment variable UE_ROOT=$UE_ROOT
+  # Find the .uproject file in the current directory
   SCRIPTDIR=$(dirname "$(readlink -f "$0")")
   cd $SCRIPTDIR
-  $UE_ROOT/Engine/Build/BatchFiles/Linux/Build.sh -projectfiles -vscode -project="$SCRIPTDIR/Blocks.uproject" -game
+  UPROJECT_FILE=$(find . -maxdepth 1 -name "*.uproject" | head -n 1)
 
-  # Insert projectairsim project folder into UE-generated Block.code-workspace
-  echo "{" > AirSimBlocks.code-workspace
-  echo "	\"folders\": [" >> AirSimBlocks.code-workspace
-  echo "		{" >> AirSimBlocks.code-workspace
-  echo "			\"name\": \"projectairsim\"," >> AirSimBlocks.code-workspace
-  echo "			\"path\": \"../..\"" >> AirSimBlocks.code-workspace
-  echo "		}," >> AirSimBlocks.code-workspace
-  sed '1,2d' Blocks.code-workspace >> AirSimBlocks.code-workspace
-  mv AirSimBlocks.code-workspace Blocks.code-workspace
+  if [ -z "$UPROJECT_FILE" ]
+  then
+    echo "ERROR: No .uproject file found in the current directory."
+    exit 1
+  fi
 
-  # Fix UE's generated game target binary names from UnrealGame to Blocks in launch.json
-  sed -i 's/UnrealGame-/Blocks-/g' .vscode/launch.json
-  sed -i 's/UnrealGame"/Blocks"/g' .vscode/launch.json
+  # Extract the project name from the .uproject file
+  PROJECT_NAME=$(basename "$UPROJECT_FILE" .uproject)
+
+  # Generate VS Code UE project files (overwrites .vscode/settings.json)
+  echo Generating VS Code project files with environment variable UE_ROOT=$UE_ROOT for project $PROJECT_NAME
+  $UE_ROOT/Engine/Build/BatchFiles/Linux/Build.sh -projectfiles -vscode -project="$SCRIPTDIR/$UPROJECT_FILE" -game
+
+  # Insert projectairsim project folder into UE-generated .code-workspace file
+  echo "{" > AirSim$PROJECT_NAME.code-workspace
+  echo "	\"folders\": [" >> AirSim$PROJECT_NAME.code-workspace
+  echo "		{" >> AirSim$PROJECT_NAME.code-workspace
+  echo "			\"name\": \"projectairsim\"," >> AirSim$PROJECT_NAME.code-workspace
+  echo "			\"path\": \"../..\"" >> AirSim$PROJECT_NAME.code-workspace
+  echo "		}," >> AirSim$PROJECT_NAME.code-workspace
+  sed '1,2d' $PROJECT_NAME.code-workspace >> AirSim$PROJECT_NAME.code-workspace
+  mv AirSim$PROJECT_NAME.code-workspace $PROJECT_NAME.code-workspace
+
+  # Fix UE's generated game target binary names from UnrealGame to the project name in launch.json
+  sed -i "s/UnrealGame-/$PROJECT_NAME-/g" .vscode/launch.json
+  sed -i "s/UnrealGame\"/$PROJECT_NAME\"/g" .vscode/launch.json
 fi


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->
This pull request enhances the `blocks_genprojfiles_vscode.sh` script to make it more flexible and project-agnostic by automatically detecting the Unreal project file and updating generated configuration files accordingly. The script now works with any `.uproject` file in the current directory, rather than being hardcoded for the "Blocks" project.

**Project detection and configuration:**

* The script now automatically finds the `.uproject` file in the current directory, extracts the project name, and uses it throughout the script instead of being hardcoded to "Blocks".
* The generated VS Code workspace and configuration files are named dynamically based on the detected project, improving compatibility with multiple Unreal projects.

**Robustness improvements:**

* The script checks for the presence of a `.uproject` file and exits with an error message if none is found, preventing misconfiguration.

**Configuration updates:**

* The script updates `.vscode/launch.json` to use the detected project name instead of the default "UnrealGame" or "Blocks", ensuring correct launch configurations for any project.

**Minor fixes:**

* Corrected a typo in an error message ("environmant" → "environment").

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->

## Screenshots and videos (if appropriate):