### PR TITLE
Skip unit test builds for simlibs_debug and simlibs_release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -434,3 +434,24 @@ add_subdirectory(rendering)
 add_subdirectory(tools)
 add_subdirectory(unity)
 add_subdirectory(vehicle_apis)
+
+if(BUILD_TESTING)
+    set(SIMLIBS_UNIT_TEST_TARGETS
+        core_sim_gtests
+        physics_gtests
+        rendering_scene_gtests
+        multirotor_api_gtests
+        rover_api_gtests
+    )
+
+    if(WIN32)
+        list(APPEND SIMLIBS_UNIT_TEST_TARGETS MavLinkTest)
+    endif()
+
+    add_custom_target(simlibs_unit_tests)
+    foreach(TEST_TARGET ${SIMLIBS_UNIT_TEST_TARGETS})
+        if(TARGET ${TEST_TARGET})
+            add_dependencies(simlibs_unit_tests ${TEST_TARGET})
+        endif()
+    endforeach()
+endif()

--- a/build_linux.mk
+++ b/build_linux.mk
@@ -125,6 +125,8 @@ clean:
 
 CTEST_DBG_CMD = ctest -C Debug -V -T test --no-compress-output
 CTEST_REL_CMD = ctest -C Release -V -T test --no-compress-output
+CMAKE_DBG_TEST_BUILD_CMD = cmake --build $(CMAKE_BUILD_DIR)/Debug --target simlibs_unit_tests
+CMAKE_REL_TEST_BUILD_CMD = cmake --build $(CMAKE_BUILD_DIR)/Release --target simlibs_unit_tests
 CMAKE_DBG_TEST_CMD = cd $(CMAKE_BUILD_DIR)/Debug && $(CTEST_DBG_CMD)
 CMAKE_REL_TEST_CMD = cd $(CMAKE_BUILD_DIR)/Release && $(CTEST_REL_CMD)
 
@@ -132,12 +134,14 @@ CMAKE_REL_TEST_CMD = cd $(CMAKE_BUILD_DIR)/Release && $(CTEST_REL_CMD)
 test_simlibs_debug: simlibs_debug
 	@echo "======================================================================="
 	@echo "Testing the ProjectAirSimLibs project for Linux64-Debug..."
+	$(CMAKE_DBG_TEST_BUILD_CMD)
 	$(CMAKE_DBG_TEST_CMD)
 
 .PHONY: test_simlibs_release
 test_simlibs_release: simlibs_release
 	@echo "======================================================================="
 	@echo "Testing the ProjectAirSimLibs project for Linux64-Release..."
+	$(CMAKE_REL_TEST_BUILD_CMD)
 	$(CMAKE_REL_TEST_CMD)
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/build_windows.mk
+++ b/build_windows.mk
@@ -126,6 +126,8 @@ clean:
 
 CTEST_DBG_CMD = ctest -C Debug -V -T test --no-compress-output
 CTEST_REL_CMD = ctest -C Release -V -T test --no-compress-output
+CMAKE_DBG_TEST_BUILD_CMD = cmake --build $(CMAKE_BUILD_DIR)\Debug --target simlibs_unit_tests
+CMAKE_REL_TEST_BUILD_CMD = cmake --build $(CMAKE_BUILD_DIR)\Release --target simlibs_unit_tests
 CMAKE_DBG_TEST_CMD = cd $(CMAKE_BUILD_DIR)\Debug && $(CTEST_DBG_CMD)
 CMAKE_REL_TEST_CMD = cd $(CMAKE_BUILD_DIR)\Release && $(CTEST_REL_CMD)
 
@@ -133,12 +135,14 @@ CMAKE_REL_TEST_CMD = cd $(CMAKE_BUILD_DIR)\Release && $(CTEST_REL_CMD)
 test_simlibs_debug: simlibs_debug
 	@echo =======================================================================
 	@echo Testing the ProjectAirSimLibs project for Win64-Debug...
+	$(CMAKE_DBG_TEST_BUILD_CMD)
 	$(CMAKE_DBG_TEST_CMD)
 
 .PHONY: test_simlibs_release
 test_simlibs_release: simlibs_release
 	@echo =======================================================================
 	@echo Testing the ProjectAirSimLibs project for Win64-Release...
+	$(CMAKE_REL_TEST_BUILD_CMD)
 	$(CMAKE_REL_TEST_CMD)
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/core_sim/test/CMakeLists.txt
+++ b/core_sim/test/CMakeLists.txt
@@ -20,6 +20,7 @@ set(CORE_SIM_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/..)
 
 add_executable(
     ${TARGET_NAME}
+    EXCLUDE_FROM_ALL
     gtest_logger.cpp
     gtest_string_utils.cpp
     gtest_transform_utils.cpp

--- a/mavlinkcom/test/CMakeLists.txt
+++ b/mavlinkcom/test/CMakeLists.txt
@@ -8,7 +8,7 @@ include_directories(
 
 set(PROJECT_CPP ${PROJECT_NAME}_sources)
 file(GLOB_RECURSE PROJECT_CPP "./*.cpp")
-add_executable(${PROJECT_NAME} ${PROJECT_CPP})
+add_executable(${PROJECT_NAME} EXCLUDE_FROM_ALL ${PROJECT_CPP})
 
 
 target_include_directories(

--- a/physics/test/CMakeLists.txt
+++ b/physics/test/CMakeLists.txt
@@ -20,6 +20,7 @@ set(TARGET_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/..)
 
 add_executable(
     ${TARGET_NAME}
+    EXCLUDE_FROM_ALL
     gtest_physics_world.cpp
     gtest_fast_physics.cpp
     gtest_unreal_physics.cpp

--- a/rendering/scene/test/CMakeLists.txt
+++ b/rendering/scene/test/CMakeLists.txt
@@ -20,6 +20,7 @@ set(TARGET_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/..)
 
 add_executable(
     ${TARGET_NAME}
+    EXCLUDE_FROM_ALL
     gtest_gltf_data_provider_test.cpp
     gtest_tile_divider.cpp
 )

--- a/vehicle_apis/multirotor_api/test/CMakeLists.txt
+++ b/vehicle_apis/multirotor_api/test/CMakeLists.txt
@@ -20,6 +20,7 @@ set(TARGET_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/..)
 
 add_executable(
     ${TARGET_NAME}
+    EXCLUDE_FROM_ALL
     gtest_simple_flight.cpp
 )
 

--- a/vehicle_apis/rover_api/test/CMakeLists.txt
+++ b/vehicle_apis/rover_api/test/CMakeLists.txt
@@ -20,6 +20,7 @@ set(TARGET_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/..)
 
 add_executable(
     ${TARGET_NAME}
+    EXCLUDE_FROM_ALL
     gtest_simple_drive.cpp
 )
 


### PR DESCRIPTION
Fixes: #

## About
This PR updates the simlibs build flow so `simlibs_debug` and `simlibs_release` only build/package the sim libraries and no longer build unit test executables as part of the default CMake build target.

The unit test executables are now marked with `EXCLUDE_FROM_ALL`, which keeps them out of the default `cmake --build` invocation used by `simlibs_debug` and `simlibs_release`.

The explicit test targets still work:
- `test_simlibs_debug`
- `test_simlibs_release`

Those targets now build the new `simlibs_unit_tests` target before running `ctest`, preserving the existing test workflow when tests are requested directly.

## How Has This Been Tested?
- Verified the CMake/test target changes statically.
- Verified all simlibs unit test executables are excluded from the default build target.
- Ran `git diff --check` successfully.

## Screenshots and videos (if appropriate):
N/A