### PR TITLE
Open3d as optional

### DIFF
--- a/client/python/projectairsim/pyproject.toml
+++ b/client/python/projectairsim/pyproject.toml
@@ -35,11 +35,13 @@ dependencies = [
   "junit-xml",
   "jsonlines",
   "Shapely",
-  "azure-storage-blob",
-  "open3d>=0.16.0"
+  "azure-storage-blob"
 ]
 
 [project.optional-dependencies]
+lidar = [
+  "open3d>=0.16.0",
+]
 autonomy = [
   "torch>=1.8.0",
   "torchvision>=0.9.0",

--- a/docs/client_setup.md
+++ b/docs/client_setup.md
@@ -62,11 +62,16 @@ A Python client uses the following to communicate with the Project AirSim simula
         cd path\to\repo
         python -m pip install -e client\python\projectairsim
 
-    If you get this error:
+    The base client install does not include Open3D. To use the LIDAR visualization
+    utilities such as `LidarDisplay` and the LIDAR example scripts, install the
+    optional `lidar` extra:
 
-        Error: Could not find a version that satisfies the requirement open3d
+        python -m pip install -e client\python\projectairsim[lidar]
 
-    most likely your virtual environment is using a 32-bit build or an unsupported version of Python. In either case, delete and rebuild the virtual environment (see step 2A) using a supported 64-bit version of Python.
+    If Open3D cannot be installed, your environment is most likely using a 32-bit
+    build or a Python version that Open3D does not publish packages for. Rebuild
+    the virtual environment (see step 2A) using a supported 64-bit version of
+    Python, or install Open3D separately through a package manager such as conda.
 
 ---
 
@@ -121,11 +126,17 @@ A Python client uses the following to communicate with the Project AirSim simula
 
         cd path\to\repo
         python -m pip install -e client\python\projectairsim
-    
-    If you get this error:
-        Error: Could not find a version that satisfies the requirement open3d
 
-    most likely your virtual environment is using a 32-bit build or an unsupported version of Python. In either case, delete and rebuild the virtual environment (see step 2A) using a supported 64-bit version of Python.
+    The base client install does not include Open3D. To use the LIDAR visualization
+    utilities such as `LidarDisplay` and the LIDAR example scripts, install the
+    optional `lidar` extra:
+
+        python -m pip install -e client/python/projectairsim[lidar]
+
+    If Open3D cannot be installed, your environment is most likely using a 32-bit
+    build or a Python version that Open3D does not publish packages for. Rebuild
+    the virtual environment (see step 2A) using a supported 64-bit version of
+    Python, or install Open3D separately through a package manager such as conda.
 
 ---
 

--- a/docs_external/eap_quickstart.md
+++ b/docs_external/eap_quickstart.md
@@ -78,9 +78,9 @@ where "{version}" is the client version ID in the form "vX.Y.Z".  For instance, 
 
 *Note regarding LIDAR visualization by Open3D:*
 
-*In order to use the client library's LIDAR visualization `LidarDisplay` utility, the Open3D pip package is needed but since [Open3D doesn't have a Python 3.9 package posted yet](https://github.com/isl-org/Open3D/issues/3983), Open3D is not included as a dependency in the binary wheel so that the Project AirSim client can be used with Python 3.9.*
+*In order to use the client library's LIDAR visualization `LidarDisplay` utility, the Open3D package is needed. Open3D is installed as an optional dependency so that the base Project AirSim client can be installed in environments where Open3D does not publish compatible packages.*
 
-*To use the LIDAR visualizations and example scripts, Open3D needs to be manually installed. For Python 3.7-3.8, you can simply run `pip install open3d`. For Python 3.9, you can download the [Open3D development wheel](http://www.open3d.org/docs/latest/getting_started.html#development-version-pip) and install it directly.*
+*To use the LIDAR visualizations and example scripts, install the optional LIDAR dependencies with `pip install projectairsim[lidar]` or, from a local checkout, `pip install -e client/python/projectairsim[lidar]`. If Open3D is not available for your Python version or platform, use a supported 64-bit Python environment or install Open3D separately through a package manager such as conda.*
 
 Please see [Project AirSim Client Setup](client_setup.md) for more details about client setup.
 

--- a/templates/client/python/projectairsim/setup.py
+++ b/templates/client/python/projectairsim/setup.py
@@ -45,10 +45,10 @@ setup(
         "jsonlines",
         "Shapely",
         "azure-storage-blob",
-        "open3d==0.16.*"  # LidarDisplay view setting is broken from 0.17.0
     ],
     python_requires=">=3.7, <4",
     extras_require={
+        "lidar": ["open3d>=0.16.0"],
         "autonomy": [
             "torch>=1.8.0",
             "torchvision>=0.9.0",


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->
This pull request refactors how the `open3d` dependency is handled for the Project AirSim Python client. Instead of being a core requirement, `open3d` is now an optional dependency grouped under a new `lidar` extra. This makes the base client install lighter and avoids installation issues in environments where Open3D is not supported. Documentation has been updated to guide users on installing the LIDAR visualization utilities and handling Open3D installation problems.

**Dependency management changes:**
- Moved `open3d` from the main dependencies list to a new optional `lidar` extra in both `pyproject.toml` and `setup.py`, so it is only installed when LIDAR features are needed. [[1]](diffhunk://#diff-b5728f177d049baf4db60646b0a8cb8cd50e0fea5f6f8bd918aa7c3891310ad3L38-R44) [[2]](diffhunk://#diff-8b2a2d87dc6e1f1f0e60202ea3be29bcc70fff3e32d4f6304203e71f381d945cL48-R51)

**Documentation updates:**
- Updated `client_setup.md` to explain that Open3D is not included by default, and added instructions for installing the `lidar` extra to enable LIDAR visualization utilities. Improved troubleshooting guidance for Open3D installation issues. [[1]](diffhunk://#diff-8a095b56e26700e8b252aab6cedc2e1bcf7b9dc8c00f3203a3db22b06b752f7bL65-R74) [[2]](diffhunk://#diff-8a095b56e26700e8b252aab6cedc2e1bcf7b9dc8c00f3203a3db22b06b752f7bL125-R139)
- Updated `eap_quickstart.md` to clarify Open3D is now an optional dependency, and provided instructions for installing LIDAR support or resolving compatibility issues.

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->

## Screenshots and videos (if appropriate):