### PR TITLE
vs code: add python debug option

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,6 @@
   "cmake.generator": "Ninja",
   "python.formatting.provider": "black",
   "python.analysis.extraPaths": [
-    "client/python"
+    "client/python/projectairsim/src"
   ]
 }

--- a/tools/update_blocks_vscode.py
+++ b/tools/update_blocks_vscode.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# Copyright (C) 2025 IAMAI CONSULTING CORP
+#
+# MIT License.
+
+"""Add Project AirSim Python debugging settings to UE-generated Blocks VS Code files."""
+
+import argparse
+import json
+from pathlib import Path
+
+
+PYTHON_CONFIGS = [
+    {
+        "name": "Python: current script (cwd = script folder)",
+        "type": "debugpy",
+        "request": "launch",
+        "program": "${file}",
+        "cwd": "${fileDirname}",
+        "console": "integratedTerminal",
+        "justMyCode": False,
+    },
+    {
+        "name": "Project AirSim: hello_drone.py",
+        "type": "debugpy",
+        "request": "launch",
+        "program": "${workspaceFolder}\\..\\..\\client\\python\\example_user_scripts\\hello_drone.py",
+        "cwd": "${workspaceFolder}\\..\\..\\client\\python\\example_user_scripts",
+        "console": "integratedTerminal",
+        "justMyCode": False,
+    },
+]
+
+PYTHON_EXTRA_PATH = "../../client/python/projectairsim/src"
+
+
+def write_json(path: Path, data: dict) -> None:
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def update_launch_json(vscode_dir: Path) -> None:
+    launch_path = vscode_dir / "launch.json"
+    launch = json.loads(launch_path.read_text(encoding="utf-8"))
+    configurations = launch.setdefault("configurations", [])
+
+    by_name = {config.get("name"): index for index, config in enumerate(configurations)}
+    for config in PYTHON_CONFIGS:
+        existing_index = by_name.get(config["name"])
+        if existing_index is None:
+            configurations.append(config)
+        else:
+            configurations[existing_index] = config
+
+    write_json(launch_path, launch)
+
+
+def update_settings_json(vscode_dir: Path) -> None:
+    settings_path = vscode_dir / "settings.json"
+    if settings_path.exists():
+        settings = json.loads(settings_path.read_text(encoding="utf-8"))
+    else:
+        settings = {}
+
+    extra_paths = settings.setdefault("python.analysis.extraPaths", [])
+    if PYTHON_EXTRA_PATH not in extra_paths:
+        extra_paths.append(PYTHON_EXTRA_PATH)
+
+    write_json(settings_path, settings)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--blocks-dir",
+        type=Path,
+        default=Path(__file__).resolve().parents[1] / "unreal" / "Blocks",
+        help="Path to the Blocks Unreal project directory.",
+    )
+    args = parser.parse_args()
+
+    vscode_dir = args.blocks_dir.resolve() / ".vscode"
+    update_launch_json(vscode_dir)
+    update_settings_json(vscode_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/unreal/Blocks/blocks_genprojfiles_vscode.bat
+++ b/unreal/Blocks/blocks_genprojfiles_vscode.bat
@@ -37,4 +37,12 @@ Unreal engine's root folder path, ex. C:\Program Files\Epic Games\UE_5.0
     echo !s! >> .vscode\airsimlaunch.json
   )
   move .vscode\airsimlaunch.json .vscode\launch.json
+
+  REM Add Project AirSim Python debugging entries to UE-generated VS Code files.
+  where python >nul 2>nul
+  if !ERRORLEVEL! == 0 (
+    python "%~dp0..\..\tools\update_blocks_vscode.py" --blocks-dir "%~dp0."
+  ) else (
+    echo:WARNING: python was not found, skipping Project AirSim Python VS Code debug configuration.
+  )
 )

--- a/unreal/Blocks/blocks_genprojfiles_vscode.sh
+++ b/unreal/Blocks/blocks_genprojfiles_vscode.sh
@@ -40,4 +40,15 @@ else
   # Fix UE's generated game target binary names from UnrealGame to the project name in launch.json
   sed -i "s/UnrealGame-/$PROJECT_NAME-/g" .vscode/launch.json
   sed -i "s/UnrealGame\"/$PROJECT_NAME\"/g" .vscode/launch.json
+
+  # Add Project AirSim Python debugging entries to UE-generated VS Code files.
+  if command -v python3 >/dev/null 2>&1
+  then
+    python3 "$SCRIPTDIR/../../tools/update_blocks_vscode.py" --blocks-dir "$SCRIPTDIR"
+  elif command -v python >/dev/null 2>&1
+  then
+    python "$SCRIPTDIR/../../tools/update_blocks_vscode.py" --blocks-dir "$SCRIPTDIR"
+  else
+    echo "WARNING: python was not found, skipping Project AirSim Python VS Code debug configuration."
+  fi
 fi


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->
This pull request adds automated configuration for Project AirSim Python development in VS Code when generating project files for the Unreal Blocks project. The main improvements are the addition of a script to inject Python debugging settings and the integration of this script into both Windows and Linux/macOS project setup workflows.

**VS Code Python development enhancements:**

* Added a new script `tools/update_blocks_vscode.py` that updates the `.vscode/launch.json` and `.vscode/settings.json` files to include Project AirSim-specific Python debugging configurations and sets the correct Python source path for code analysis.
* Modified `.vscode/settings.json` to update the `python.analysis.extraPaths` entry, ensuring the correct AirSim Python source directory is used for code completion and analysis.

**Integration into project setup scripts:**

* Updated `unreal/Blocks/blocks_genprojfiles_vscode.bat` (Windows) to call the new Python script after generating VS Code files, adding AirSim Python debug configurations if Python is available.
* Updated `unreal/Blocks/blocks_genprojfiles_vscode.sh` (Linux/macOS) to similarly invoke the script, supporting both `python3` and `python`, and providing a warning if Python is not found.

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->

## Screenshots and videos (if appropriate):