### PR TITLE
fix: add float() casts in ROS geometry_msgs coordinate conversion functions

### DIFF
--- a/ros/node/projectairsim-rosbridge/src/projectairsim_rosbridge/utils.py
+++ b/ros/node/projectairsim-rosbridge/src/projectairsim_rosbridge/utils.py
@@ -229,9 +229,9 @@ def to_ros_point(projectairsim_vector):
     to ROS orientation (RHS, X-forward, Y-left, Z-up)
     """
     return rosgeommsg.Point(
-        x=projectairsim_vector["x"],
-        y=-projectairsim_vector["y"],
-        z=-projectairsim_vector["z"],
+        x=float(projectairsim_vector["x"]),
+        y=float(-projectairsim_vector["y"]),
+        z=float(-projectairsim_vector["z"]),
     )
 
 
@@ -252,7 +252,7 @@ def to_ros_position_list2list(projectairsim_list):
     Convert a vector from Project AirSim orientation (RHS, X-forward, Y-right, Z-down)
     to ROS orientation (RHS, X-forward, Y-left, Z-up)
     """
-    return (projectairsim_list[0], -projectairsim_list[1], -projectairsim_list[2])
+    return (float(projectairsim_list[0]), float(-projectairsim_list[1]), float(-projectairsim_list[2]))
 
 
 def to_ros_position_vector3(projectairsim_vector):
@@ -261,9 +261,9 @@ def to_ros_position_vector3(projectairsim_vector):
     to ROS orientation (RHS, X-forward, Y-left, Z-up)
     """
     return rosgeommsg.Vector3(
-        x=projectairsim_vector["x"],
-        y=-projectairsim_vector["y"],
-        z=-projectairsim_vector["z"],
+        x=float(projectairsim_vector["x"]),
+        y=float(-projectairsim_vector["y"]),
+        z=float(-projectairsim_vector["z"]),
     )
 
 
@@ -273,10 +273,10 @@ def to_ros_quaternion(projectairsim_quaternion):
     to ROS orientation (RHS, X-forward, Y-left, Z-up)
     """
     return rosgeommsg.Quaternion(
-        x=projectairsim_quaternion["x"],
-        y=-projectairsim_quaternion["y"],
-        z=-projectairsim_quaternion["z"],
-        w=projectairsim_quaternion["w"],
+        x=float(projectairsim_quaternion["x"]),
+        y=float(-projectairsim_quaternion["y"]),
+        z=float(-projectairsim_quaternion["z"]),
+        w=float(projectairsim_quaternion["w"]),
     )
 
 
@@ -299,8 +299,8 @@ def to_ros_quaternion_list2list(projectairsim_list):
     to ROS orientation (RHS, X-forward, Y-left, Z-up)
     """
     return (
-        projectairsim_list[0],
-        -projectairsim_list[1],
-        -projectairsim_list[2],
-        projectairsim_list[3],
+        float(projectairsim_list[0]),
+        float(-projectairsim_list[1]),
+        float(-projectairsim_list[2]),
+        float(projectairsim_list[3]),
     )


### PR DESCRIPTION
## Summary

- ROS 2 \`geometry_msgs\` fields (\`Point\`, \`Vector3\`, \`Quaternion\`) assert that assigned values are \`float\`; ProjectAirSim delivers pose/position data as Python \`int\`, triggering \`AssertionError: The 'x' field must be of type 'float'\` at runtime.
- Added explicit \`float()\` casts on every numeric component in five functions in \`utils.py\`: \`to_ros_point\`, \`to_ros_position_vector3\`, \`to_ros_position_list2list\`, \`to_ros_quaternion\`, and \`to_ros_quaternion_list2list\`.

## Test plan

- [x] Run the ROS bridge with a live ProjectAirSim instance and confirm no \`AssertionError\` is raised when pose/transform data is published.
- [x] Verify that coordinate values (including negated components like \`-vector["y"]\`) are correctly cast and published to ROS topics.