### PR TITLE
Gpu lidar fix

### DIFF
--- a/client/python/example_user_scripts/depth_lidar.py
+++ b/client/python/example_user_scripts/depth_lidar.py
@@ -4,11 +4,11 @@ import asyncio
 import time
 from pathlib import Path
 
-import cv2
 import numpy as np
 
 from projectairsim import Drone, ProjectAirSimClient, World
-from projectairsim.lidar_utils import LidarDisplay
+from projectairsim.image_utils import ImageDisplay
+from projectairsim.lidar_utils import LidarTopDownRenderer
 from projectairsim.utils import projectairsim_log
 
 
@@ -72,13 +72,12 @@ class PointCloudStats:
 async def main():
     client = ProjectAirSimClient()
     lidar_cloud_stats = PointCloudStats("lidar1.lidar")
-    lidar_cloud_display = LidarDisplay(
-        win_name="Lidar PointCloud",
-        color_mode=LidarDisplay.COLOR_INTENSITY,
+    image_display = ImageDisplay(num_subwin=1, subwin_width=640, subwin_height=640)
+    lidar_cloud_window = "Lidar PointCloud"
+    lidar_cloud_renderer = LidarTopDownRenderer(
         width=640,
-        height=360,
-        x=40,
-        y=420,
+        height=640,
+        range_m=60.0,
     )
     lidar_cloud_topic = None
     drone = None
@@ -100,14 +99,19 @@ async def main():
             f"Subscribing lidar pointcloud stream: {lidar_cloud_topic}"
         )
 
-        lidar_cloud_display.start()
+        image_display.add_image(lidar_cloud_window, subwin_idx=0)
+        image_display.start()
 
         client.subscribe(
             lidar_cloud_topic,
             safe_topic_callback(
                 "lidar_cloud",
                 lambda _, lidar_msg: handle_lidar_cloud(
-                    lidar_msg, lidar_cloud_stats, lidar_cloud_display
+                    lidar_msg,
+                    lidar_cloud_stats,
+                    lidar_cloud_renderer,
+                    image_display,
+                    lidar_cloud_window,
                 ),
             ),
         )
@@ -156,14 +160,22 @@ async def main():
             drone.disarm()
             drone.disable_api_control()
 
-        lidar_cloud_display.stop()
-        cv2.destroyAllWindows()
+        image_display.stop()
         client.disconnect()
 
 
-def handle_lidar_cloud(lidar_msg, lidar_cloud_stats, lidar_cloud_display):
+def handle_lidar_cloud(
+    lidar_msg,
+    lidar_cloud_stats,
+    lidar_cloud_renderer,
+    image_display,
+    lidar_cloud_window,
+):
     lidar_cloud_stats.receive(lidar_msg)
-    lidar_cloud_display.receive(lidar_msg)
+    image_display.receive(
+        lidar_cloud_renderer.render_image_msg(lidar_msg),
+        lidar_cloud_window,
+    )
 
 
 if __name__ == "__main__":

--- a/client/python/example_user_scripts/lidar_basic.py
+++ b/client/python/example_user_scripts/lidar_basic.py
@@ -7,28 +7,60 @@ Demonstrates using a basic lidar sensor with a cylindrical scan pattern.
 """
 
 import asyncio
+import math
+import time
+from pathlib import Path
 
 from projectairsim import ProjectAirSimClient, Drone, World
+from projectairsim.lidar_utils import LidarTopDownRenderer
 from projectairsim.utils import projectairsim_log
 from projectairsim.image_utils import ImageDisplay
-from projectairsim.lidar_utils import LidarDisplay
+
+
+class LidarStats:
+    def __init__(self):
+        self.message_count = 0
+        self.last_report_wall = 0.0
+
+    def receive(self, lidar_data):
+        if lidar_data is None:
+            return
+
+        point_count = int(len(lidar_data.get("point_cloud", [])) / 3)
+        if point_count == 0:
+            return
+
+        self.message_count += 1
+        now = time.time()
+        if self.message_count == 1 or now - self.last_report_wall >= 1.0:
+            projectairsim_log().info(
+                f"lidar1: msg={self.message_count} points={point_count}"
+            )
+            self.last_report_wall = now
+
+
+def receive_lidar(lidar_data, lidar_stats, lidar_renderer, image_display, image_name):
+    lidar_stats.receive(lidar_data)
+    image_display.receive(lidar_renderer.render_image_msg(lidar_data), image_name)
 
 
 # Async main function to wrap async drone commands
 async def main():
     # Create a Project AirSim client
     client = ProjectAirSimClient()
+    lidar_stats = LidarStats()
 
     # Initialize an ImageDisplay object to display camera sub-windows
     image_display = ImageDisplay()
 
     # ----------------------------------------------------------------------------------
 
-    # Initialize a LidarDisplay object for a point cloud visualization sub-window
-    lidar_subwin = image_display.get_subwin_info(2)
-    lidar_display = LidarDisplay(
-        x=lidar_subwin["x"], y=lidar_subwin["y"] + 30
-    )  # add 30 y-pix for window title bar
+    # Initialize a top-down LIDAR image renderer.
+    lidar_renderer = LidarTopDownRenderer(
+        width=640,
+        height=640,
+        range_m=60.0,
+    )
 
     # ----------------------------------------------------------------------------------
 
@@ -37,7 +69,13 @@ async def main():
         client.connect()
 
         # Create a World object to interact with the sim world and load a scene
-        world = World(client, "scene_lidar_drone.jsonc", delay_after_load_sec=2)
+        sim_config_path = str(Path(__file__).resolve().parent / "sim_config")
+        world = World(
+            client,
+            "scene_lidar_drone.jsonc",
+            delay_after_load_sec=2,
+            sim_config_path=sim_config_path,
+        )
 
         # Create a Drone object to interact with a drone in the loaded sim world
         drone = Drone(client, world, "Drone1")
@@ -65,22 +103,24 @@ async def main():
             lambda _, depth: image_display.receive(depth, depth_name),
         )
 
+        lidar_name = "LIDAR"
+        image_display.add_image(lidar_name, resize_x=640, resize_y=640)
+
         image_display.start()
 
         # ------------------------------------------------------------------------------
 
         client.subscribe(
             drone.sensors["lidar1"]["lidar"],
-            lambda _, lidar: lidar_display.receive(lidar),
+            lambda _, lidar: receive_lidar(
+                lidar, lidar_stats, lidar_renderer, image_display, lidar_name
+            ),
         )
 
         # client.subscribe(
         #     drone.sensors["lidar1"]["lidar"],
         #     lambda _, lidar: print(lidar),
         # )
-
-        lidar_display.start()
-
         # ------------------------------------------------------------------------------
 
         # Set the drone to be ready to fly
@@ -99,6 +139,13 @@ async def main():
             v_north=4.0, v_east=0.0, v_down=0.0, duration=12.0
         )
         await move_task
+
+        projectairsim_log().info("Yaw 720 degrees")
+        yaw_task = await drone.rotate_by_yaw_rate_async(
+            yaw_rate=math.radians(12.0),
+            duration=20.0,
+        )
+        await yaw_task
 
         projectairsim_log().info("Move north-east")
         move_task = await drone.move_by_velocity_async(
@@ -130,10 +177,6 @@ async def main():
         client.disconnect()
 
         image_display.stop()
-
-        # ------------------------------------------------------------------------------
-
-        lidar_display.stop()
 
         # ------------------------------------------------------------------------------
 

--- a/client/python/example_user_scripts/sim_config/robot_quadrotor_fastphysics_lidar.jsonc
+++ b/client/python/example_user_scripts/sim_config/robot_quadrotor_fastphysics_lidar.jsonc
@@ -424,25 +424,27 @@
     {
       "id": "lidar1",
       "type": "lidar",
+      "lidar-type": "gpu_cylindrical",
       "enabled": true,
       "parent-link": "Frame",
-      "number-of-channels": 16,
+      "number-of-channels": 32,
       "range": 100,
-      "points-per-second": 100000,
+      "points-per-second": 180000,
       "horizontal-rotation-frequency": 10,
-      "horizontal-fov-start-deg": 0.0,
+      "horizontal-fov-start-deg": 0,
       "horizontal-fov-end-deg": 360.0,
-      "vertical-fov-upper-deg": 0.0,
-      "vertical-fov-lower-deg": -90.0,
+      "vertical-fov-upper-deg": 15.0,
+      "vertical-fov-lower-deg": -15.0,
       "disable-self-hits": true,
       "draw-debug-points": false,
-      "origin": {
-        "xyz": "0 0 0.2",
-        "rpy-deg": "0 0 0"
-      },
+      "report-frequency": 0,
       "report-point-cloud": true,
       "report-azimuth-elevation-range": false,
-      "report-no-return-points": false
+      "report-no-return-points": false,
+      "origin": {
+        "xyz": "0 0 1.0",
+        "rpy-deg": "0 0 0"
+      }
     },
     {
       "id": "GPS",

--- a/client/python/projectairsim/src/projectairsim/lidar_utils.py
+++ b/client/python/projectairsim/src/projectairsim/lidar_utils.py
@@ -2,12 +2,81 @@ from argparse import ArgumentError
 import multiprocessing as mp
 import time
 
+import cv2
 import numpy as np
 import open3d as o3d
 from matplotlib import cm
 from projectairsim.image_utils import SEGMENTATION_PALLETE
 
 # from projectairsim.utils import projectairsim_log
+
+
+class LidarTopDownRenderer:
+    """Render lidar point clouds as top-down OpenCV-compatible image messages.
+
+    The output uses the sensor frame with forward plotted upward and right plotted
+    to the right. Point color is based on the down-axis value.
+    """
+
+    def __init__(self, width=640, height=640, range_m=60.0):
+        self.width = width
+        self.height = height
+        self.range_m = range_m
+
+    def make_blank_image(self):
+        image = np.zeros((self.height, self.width, 3), dtype=np.uint8)
+        center = (self.width // 2, self.height // 2)
+        cv2.circle(image, center, 3, (255, 255, 255), -1)
+        return image
+
+    def render_lidar(self, lidar_data):
+        point_cloud = lidar_data.get("point_cloud")
+        if point_cloud is None or len(point_cloud) == 0:
+            return self.make_blank_image()
+
+        points = np.asarray(point_cloud, dtype=np.float32).reshape((-1, 3))
+        image = self.make_blank_image()
+
+        scale = min(self.width, self.height) / (2.0 * self.range_m)
+        px = np.round(self.width / 2.0 + points[:, 1] * scale).astype(np.int32)
+        py = np.round(self.height / 2.0 - points[:, 0] * scale).astype(np.int32)
+
+        in_bounds = (px >= 0) & (px < self.width) & (py >= 0) & (py < self.height)
+        if not np.any(in_bounds):
+            return image
+
+        z_down = points[in_bounds, 2]
+        z_norm = np.clip((z_down - z_down.min()) / (np.ptp(z_down) + 1e-6), 0.0, 1.0)
+        colors = cv2.applyColorMap(
+            (255.0 * z_norm).astype(np.uint8), cv2.COLORMAP_TURBO
+        )
+        image[py[in_bounds], px[in_bounds]] = colors[:, 0, :]
+
+        cv2.line(
+            image,
+            (self.width // 2, 0),
+            (self.width // 2, self.height - 1),
+            (60, 60, 60),
+            1,
+        )
+        cv2.line(
+            image,
+            (0, self.height // 2),
+            (self.width - 1, self.height // 2),
+            (60, 60, 60),
+            1,
+        )
+        cv2.circle(image, (self.width // 2, self.height // 2), 4, (255, 255, 255), -1)
+        return image
+
+    def render_image_msg(self, lidar_data):
+        image = self.render_lidar(lidar_data)
+        return {
+            "encoding": "BGR",
+            "height": self.height,
+            "width": self.width,
+            "data": image.tobytes(),
+        }
 
 
 class LidarDisplay:

--- a/client/python/projectairsim/tests/sim_config/robot_test_quadrotor_fastphysics_depth_lidar.jsonc
+++ b/client/python/projectairsim/tests/sim_config/robot_test_quadrotor_fastphysics_depth_lidar.jsonc
@@ -302,6 +302,108 @@
   ],
   "sensors": [
     {
+      "id": "Chase",
+      "type": "camera",
+      "enabled": true,
+      "parent-link": "Frame",
+      "capture-interval": 0.03,
+      "capture-settings": [
+        {
+          "image-type": 0,
+          "width": 1280,
+          "height": 720,
+          "fov-degrees": 90,
+          "capture-enabled": true,
+          "streaming-enabled": true,
+          "pixels-as-float": false,
+          "compress": false,
+          "target-gamma": 2.5
+        }
+      ],
+      "gimbal": {
+        "lock-roll": true,
+        "lock-pitch": true,
+        "lock-yaw": false
+      },
+      "origin": {
+        "xyz": "-10.0 0.0 -1.0",
+        "rpy-deg": "0 -11.46 0"
+      }
+    },
+    {
+      "id": "DownCamera",
+      "type": "camera",
+      "enabled": true,
+      "parent-link": "Frame",
+      "capture-interval": 0.02,
+      "capture-settings": [
+        {
+          "image-type": 0,
+          "width": 400,
+          "height": 225,
+          "fov-degrees": 90,
+          "capture-enabled": true,
+          "streaming-enabled": false,
+          "pixels-as-float": false,
+          "compress": false,
+          "target-gamma": 2.5
+        },
+        {
+          "image-type": 1,
+          "width": 400,
+          "height": 225,
+          "fov-degrees": 90,
+          "capture-enabled": false,
+          "streaming-enabled": false,
+          "pixels-as-float": false,
+          "compress": false
+        },
+        {
+          "image-type": 2,
+          "width": 400,
+          "height": 225,
+          "fov-degrees": 90,
+          "capture-enabled": true,
+          "streaming-enabled": false,
+          "pixels-as-float": false,
+          "compress": false
+        },
+        {
+          "image-type": 3,
+          "width": 400,
+          "height": 225,
+          "fov-degrees": 90,
+          "capture-enabled": false,
+          "streaming-enabled": false,
+          "pixels-as-float": false,
+          "compress": false
+        }
+      ],
+      "noise-settings": [
+        {
+          "enabled": false,
+          "image-type": 1,
+          "rand-contrib": 0.2,
+          "rand-speed": 100000.0,
+          "rand-size": 500.0,
+          "rand-density": 2,
+          "horz-wave-contrib": 0.03,
+          "horz-wave-strength": 0.08,
+          "horz-wave-vert-size": 1.0,
+          "horz-wave-screen-size": 1.0,
+          "horz-noise-lines-contrib": 1.0,
+          "horz-noise-lines-density-y": 0.01,
+          "horz-noise-lines-density-xy": 0.5,
+          "horz-distortion-contrib": 1.0,
+          "horz-distortion-strength": 0.002
+        }
+      ],
+      "origin": {
+        "xyz": "0 0.0 0.0",
+        "rpy-deg": "0 -90 0"
+      }
+    },
+    {
   "id": "lidar1",
   "type": "lidar",
   "lidar-type": "depth_lidar",

--- a/client/python/projectairsim/tests/sim_config/robot_test_quadrotor_fastphysics_lidar.jsonc
+++ b/client/python/projectairsim/tests/sim_config/robot_test_quadrotor_fastphysics_lidar.jsonc
@@ -302,6 +302,108 @@
   ],
   "sensors": [
     {
+      "id": "Chase",
+      "type": "camera",
+      "enabled": true,
+      "parent-link": "Frame",
+      "capture-interval": 0.03,
+      "capture-settings": [
+        {
+          "image-type": 0,
+          "width": 1280,
+          "height": 720,
+          "fov-degrees": 90,
+          "capture-enabled": true,
+          "streaming-enabled": true,
+          "pixels-as-float": false,
+          "compress": false,
+          "target-gamma": 2.5
+        }
+      ],
+      "gimbal": {
+        "lock-roll": true,
+        "lock-pitch": true,
+        "lock-yaw": false
+      },
+      "origin": {
+        "xyz": "-10.0 0.0 -1.0",
+        "rpy-deg": "0 -11.46 0"
+      }
+    },
+    {
+      "id": "DownCamera",
+      "type": "camera",
+      "enabled": true,
+      "parent-link": "Frame",
+      "capture-interval": 0.02,
+      "capture-settings": [
+        {
+          "image-type": 0,
+          "width": 400,
+          "height": 225,
+          "fov-degrees": 90,
+          "capture-enabled": true,
+          "streaming-enabled": false,
+          "pixels-as-float": false,
+          "compress": false,
+          "target-gamma": 2.5
+        },
+        {
+          "image-type": 1,
+          "width": 400,
+          "height": 225,
+          "fov-degrees": 90,
+          "capture-enabled": false,
+          "streaming-enabled": false,
+          "pixels-as-float": false,
+          "compress": false
+        },
+        {
+          "image-type": 2,
+          "width": 400,
+          "height": 225,
+          "fov-degrees": 90,
+          "capture-enabled": true,
+          "streaming-enabled": false,
+          "pixels-as-float": false,
+          "compress": false
+        },
+        {
+          "image-type": 3,
+          "width": 400,
+          "height": 225,
+          "fov-degrees": 90,
+          "capture-enabled": false,
+          "streaming-enabled": false,
+          "pixels-as-float": false,
+          "compress": false
+        }
+      ],
+      "noise-settings": [
+        {
+          "enabled": false,
+          "image-type": 1,
+          "rand-contrib": 0.2,
+          "rand-speed": 100000.0,
+          "rand-size": 500.0,
+          "rand-density": 2,
+          "horz-wave-contrib": 0.03,
+          "horz-wave-strength": 0.08,
+          "horz-wave-vert-size": 1.0,
+          "horz-wave-screen-size": 1.0,
+          "horz-noise-lines-contrib": 1.0,
+          "horz-noise-lines-density-y": 0.01,
+          "horz-noise-lines-density-xy": 0.5,
+          "horz-distortion-contrib": 1.0,
+          "horz-distortion-strength": 0.002
+        }
+      ],
+      "origin": {
+        "xyz": "0 0.0 0.0",
+        "rpy-deg": "0 -90 0"
+      }
+    },
+    {
       "id": "lidar1",
       "type": "lidar",
       "enabled": true,

--- a/client/python/projectairsim/tests/sim_config/robot_test_quadrotor_fastphysics_mid70.jsonc
+++ b/client/python/projectairsim/tests/sim_config/robot_test_quadrotor_fastphysics_mid70.jsonc
@@ -313,7 +313,7 @@
           "width": 1280,
           "height": 720,
           "fov-degrees": 90,
-          "capture-enabled": false,
+          "capture-enabled": true,
           "streaming-enabled": true,
           "pixels-as-float": false,
           "compress": false,
@@ -335,7 +335,7 @@
       "type": "camera",
       "enabled": true,
       "parent-link": "Frame",
-      "capture-interval": 0.001,
+      "capture-interval": 0.02,
       "capture-settings": [
         {
           "image-type": 0,
@@ -402,7 +402,7 @@
         "xyz": "0 0.0 0.0",
         "rpy-deg": "0 -90 0"
       }
-    },
+    },  
     {
       "id": "IMU1",
       "type": "imu",

--- a/unreal/Blocks/Plugins/ProjectAirSim/Source/ProjectAirSim/Private/Sensors/GPULidar.cpp
+++ b/unreal/Blocks/Plugins/ProjectAirSim/Source/ProjectAirSim/Private/Sensors/GPULidar.cpp
@@ -21,14 +21,28 @@
 #include "Misc/FileHelper.h"
 #include "Runtime/Core/Public/Async/ParallelFor.h"
 #include "Runtime/Engine/Classes/Kismet/KismetMathLibrary.h"
-#include "SceneView.h"
 #include "Serialization/BufferArchive.h"
 #include "UObject/ConstructorHelpers.h"
 #include "UnrealCameraRenderRequest.h"
 #include "UnrealLogger.h"
 #include "UnrealTransforms.h"
 
+#include <cmath>
+
 namespace projectairsim = microsoft::projectairsim;
+
+namespace {
+
+float NormalizeGPULidarAngleDeg(float AngleDeg) {
+  return std::fmod(360.0f + std::fmod(AngleDeg, 360.0f), 360.0f);
+}
+
+float GetHorizontalFovSpanDeg(float StartAngleDeg, float EndAngleDeg) {
+  const float SpanDeg = NormalizeGPULidarAngleDeg(EndAngleDeg - StartAngleDeg);
+  return FMath::IsNearlyZero(SpanDeg) ? 360.0f : SpanDeg;
+}
+
+}  // namespace
 
 UGPULidar::UGPULidar(const FObjectInitializer& ObjectInitializer)
     : UUnrealSensor(ObjectInitializer), IntensityExtension(nullptr) {
@@ -61,14 +75,6 @@ void UGPULidar::Initialize(const projectairsim::Lidar& SimLidar) {
   FCoreDelegates::OnEndFrameRT.AddUObject(this, &UGPULidar::EndFrameCallbackRT);
 }
 
-void ExecuteOnRenderThread1(const TFunctionRef<void()>& Function) {
-  check(IsInGameThread());
-
-  ENQUEUE_RENDER_COMMAND(ExecuteOnRenderThread1)
-  ([Function](FRHICommandListImmediate& /*RHICmdList*/) { Function(); });
-  FlushRenderingCommands();
-}
-
 void UGPULidar::TickComponent(float DeltaTime, ELevelTick TickType,
                               FActorComponentTickFunction* ThisTickFunction) {
   Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
@@ -77,48 +83,28 @@ void UGPULidar::TickComponent(float DeltaTime, ELevelTick TickType,
   const TimeSec SimTimeDeltaSec =
       projectairsim::SimClock::Get()->NanosToSec(CurSimTime - LastSimTime);
 
-  Simulate(SimTimeDeltaSec);
+  const bool bHasNewLidarData = Simulate(SimTimeDeltaSec, CurSimTime);
 
-  const auto LidarTransformStamped = UnrealTransform::GetPoseNed(this);
-  projectairsim::Pose LidarPose(LidarTransformStamped.translation_,
-                              LidarTransformStamped.rotation_);
+  if (bHasNewLidarData) {
+    projectairsim::LidarMessage LidarMsg(
+        PointCloudTime, PointCloud, AzimuthElevationRangeCloud,
+        SegmentationCloud, IntensityCloud, LaserIndexCloud, PointCloudPose);
+    Lidar.PublishLidarMsg(LidarMsg);
+  }
 
-  projectairsim::LidarMessage LidarMsg(CurSimTime, PointCloud, AzimuthElevationRangeCloud, SegmentationCloud,
-                                     IntensityCloud, LaserIndexCloud, LidarPose);
-  Lidar.PublishLidarMsg(LidarMsg);
   LastSimTime = CurSimTime;
 }
 
 void UGPULidar::SetupLidarFromSettings(
     const projectairsim::LidarSettings& LidarSettings) {
   Settings = projectairsim::LidarSettings(LidarSettings);
-  // Start the sweep at the configured azimuth so partial-FOV sensors begin in
-  // the same sector requested by the scene config.
-  CurrentHorizontalAngleDeg =
-      std::fmod(Settings.horizontal_fov_start_deg + 360.0f, 360.0f);
+  Settings.horizontal_fov_start_deg =
+      NormalizeGPULidarAngleDeg(Settings.horizontal_fov_start_deg);
+  Settings.horizontal_fov_end_deg =
+      NormalizeGPULidarAngleDeg(Settings.horizontal_fov_end_deg);
 
   InitializePose();
   SetUpCams();
-}
-
-FMatrix GetProjectionMat(USceneCaptureComponent2D* CaptureComp,
-                         float aspectRatio) {
-  FMinimalViewInfo ViewInfo;
-  ViewInfo.Location = CaptureComp->GetComponentTransform().GetLocation();
-  ViewInfo.Rotation =
-      CaptureComp->GetComponentTransform().GetRotation().Rotator();
-  ViewInfo.FOV = CaptureComp->FOVAngle;
-  ViewInfo.ProjectionMode = CaptureComp->ProjectionType;
-  ViewInfo.AspectRatio = aspectRatio;
-  ViewInfo.OrthoNearClipPlane = GNearClippingPlane;  // need for prespective?
-  ViewInfo.OrthoFarClipPlane = 10000;                // TODO
-  ViewInfo.bConstrainAspectRatio = true;
-
-  if (CaptureComp->bUseCustomProjectionMatrix == true) {
-    return CaptureComp->CustomProjectionMatrix;
-  } else {
-    return ViewInfo.CalculateProjectionMatrix();
-  }
 }
 
 void UGPULidar::SetupSceneCapture(
@@ -212,33 +198,6 @@ void UGPULidar::SetUpCams() {
     CameraComponent->FieldOfView = HorizontalAngle;
     CameraComponent->AspectRatio = aspectRatio;
 
-    // Projection matrix for all cams should be same
-    FMatrix proj = GetProjectionMat(SceneCapture, aspectRatio);
-    ProjectionMat = proj;
-
-    if (i == 0) {
-      FIntRect ScreenRect(0, 0, CamFrustrumWidth, CamFrustrumHeight);
-      FSceneViewProjectionData ProjectionData;
-      ProjectionData.ViewOrigin =
-          SceneCapture->GetComponentTransform().GetLocation();
-      // Apply rotation matrix of camera's pose plus the rotation matrix for
-      // converting Unreal's world axes to the camera's view axes (z forward,
-      // etc).
-      ProjectionData.ViewRotationMatrix =
-          FInverseRotationMatrix(
-              SceneCapture->GetComponentTransform().GetRotation().Rotator()) *
-          FMatrix(FPlane(0, 0, 1, 0), FPlane(1, 0, 0, 0), FPlane(0, 1, 0, 0),
-                  FPlane(0, 0, 0, 1));
-      ProjectionData.ProjectionMatrix = ProjectionMat;
-      ProjectionData.SetConstrainedViewRectangle(ScreenRect);
-      Cam1ProjData = ProjectionData;
-    }
-
-    if (i == 0) {
-      cam1loc = SceneCapture->GetComponentTransform().GetLocation();
-      cam1Rot = SceneCapture->GetComponentTransform().GetRotation();
-    }
-
     // Render intensity to target texture
     std::string IntensityCaptureStr = "IntensityCapture_" + std::to_string(i);
     auto IntensityCaptureComponent =
@@ -283,7 +242,8 @@ void UGPULidar::InitializePose() {
       InitializedRPY.x(), InitializedRPY.y(), InitializedRPY.z());
 }
 
-void UGPULidar::Simulate(const float SimTimeDeltaSec) {
+bool UGPULidar::Simulate(const float SimTimeDeltaSec,
+                         const TimeNano CurSimTime) {
   PointCloud.clear();
   AzimuthElevationRangeCloud.clear();
   SegmentationCloud.clear();
@@ -311,31 +271,35 @@ void UGPULidar::Simulate(const float SimTimeDeltaSec) {
     UnrealLogger::Log(projectairsim::LogLevel::kWarning,
                       TEXT("[UnrealLidar] No points requested this frame, "
                            "try increasing the number of points per second."));
-    return;
+    return false;
   }
 
-  bool useCPUVersion = false;
-
-  const float AngleDistanceOfTickDeg =
-      Settings.horizontal_rotation_frequency * 360.0f * SimTimeDeltaSec;
+  const float HorizontalFOVDeg =
+      GetHorizontalFovSpanDeg(Settings.horizontal_fov_start_deg,
+                              Settings.horizontal_fov_end_deg);
   // Create parameters & pass data
   FLidarPointCloudCSParameters PointCloudParams;
-  PointCloudParams.ProjectionMat = ProjectionMat;
-  PointCloudParams.ViewProjectionMatInv =
-      FMatrix44f(Cam1ProjData.ComputeViewProjectionMatrix().Inverse());
   PointCloudParams.HorizontalResolution = HorizontalResolution;
   PointCloudParams.LaserNums = Settings.number_of_channels;
   PointCloudParams.LaserRange =
       projectairsim::TransformUtils::ToCentimeters(Settings.range);
-  PointCloudParams.HorizontalFOV = AngleDistanceOfTickDeg;
-  // The shader still samples only the angular slice swept this tick, but it
-  // now clips that slice against the sensor's configured horizontal window.
+  PointCloudParams.HorizontalFOV = HorizontalFOVDeg;
+  // For this test path, do not rotate a simulated sweep over time. Sample the
+  // configured horizontal FOV from its configured start angle every frame.
   PointCloudParams.HorizontalFOVStartDeg = Settings.horizontal_fov_start_deg;
   PointCloudParams.HorizontalFOVEndDeg = Settings.horizontal_fov_end_deg;
-  PointCloudParams.CurrentHorizontalAngleDeg = CurrentHorizontalAngleDeg;
-  PointCloudParams.VerticalFOV = Settings.vertical_fov_upper_deg *
-                                 2.f;  // assuming symmetrical < 30 for now
+  PointCloudParams.CurrentHorizontalAngleDeg =
+      Settings.horizontal_fov_start_deg;
+  const auto LidarTransformStamped = UnrealTransform::GetPoseNed(this);
+  PointCloudParams.CaptureTime = CurSimTime;
+  PointCloudParams.LidarPose =
+      projectairsim::Pose(LidarTransformStamped.translation_,
+                          LidarTransformStamped.rotation_);
+  PointCloudParams.VerticalFOVUpperDeg = Settings.vertical_fov_upper_deg;
+  PointCloudParams.VerticalFOVLowerDeg = Settings.vertical_fov_lower_deg;
   PointCloudParams.NumCams = DepthSceneCaptures.size();
+  PointCloudParams.CameraHorizontalFOVDeg =
+      360.0f / static_cast<float>(PointCloudParams.NumCams);
   PointCloudParams.CamFrustrumHeight = CamFrustrumHeight;
   PointCloudParams.CamFrustrumWidth = CamFrustrumWidth;
   // Bind one depth texture per quadrant so the compute shader can project each
@@ -362,24 +326,22 @@ void UGPULidar::Simulate(const float SimTimeDeltaSec) {
   PointCloudParams.RotationMatCam3 = FMatrix44f(CamRotationMats[2]);
   PointCloudParams.RotationMatCam4 = FMatrix44f(CamRotationMats[3]);
 
-  auto RenderTargetResource =
-      DepthSceneCaptures[0]
-          ->TextureTarget->GameThread_GetRenderTargetResource();
-
   IntensityExtension->UpdateParameters(PointCloudParams);
 
   auto world = this->GetWorld();
 
-  static int startIndex = 0;
-  static int numPointsToDraw =
-      HorizontalResolution *
-      Settings.number_of_channels;  // TODO: extend for more cams
+  if (!IntensityExtension->bHasUnreadLidarPointCloudData) {
+    return false;
+  }
 
   auto pointCloudData = IntensityExtension->LidarPointCloudData;
+  PointCloudTime = IntensityExtension->LidarPointCloudTime;
+  PointCloudPose = IntensityExtension->LidarPointCloudPose;
+  IntensityExtension->bHasUnreadLidarPointCloudData = false;
   auto cameraTransform = DepthSceneCaptures[0]->GetComponentTransform();
 
   if (pointCloudData.size()) {
-    for (int i = startIndex; i < pointCloudData.size(); i++) {
+    for (int i = 0; i < pointCloudData.size(); i++) {
       auto point = FVector(pointCloudData[i].X, pointCloudData[i].Y,
                            pointCloudData[i].Z);
 
@@ -410,8 +372,7 @@ void UGPULidar::Simulate(const float SimTimeDeltaSec) {
     }
   }
 
-  CurrentHorizontalAngleDeg =
-      std::fmod(CurrentHorizontalAngleDeg + AngleDistanceOfTickDeg, 360.0f);
+  return true;
 }
 
 void UGPULidar::BeginFrameCallback() { bool f = false; }

--- a/unreal/Blocks/Plugins/ProjectAirSim/Source/ProjectAirSim/Private/Sensors/GPULidar.h
+++ b/unreal/Blocks/Plugins/ProjectAirSim/Source/ProjectAirSim/Private/Sensors/GPULidar.h
@@ -50,7 +50,7 @@ UCLASS() class UGPULidar : public UUnrealSensor {
  private:
   void InitializePose();
 
-  void Simulate(const float DeltaTime);
+  bool Simulate(const float DeltaTime, const TimeNano CurSimTime);
 
  private:
   void BeginFrameCallback();
@@ -61,15 +61,15 @@ UCLASS() class UGPULidar : public UUnrealSensor {
  private:
   microsoft::projectairsim::Lidar Lidar;
   microsoft::projectairsim::LidarSettings Settings;
-  float CurrentHorizontalAngleDeg = 0.0f;
   std::vector<float> PointCloud;
   std::vector<float> AzimuthElevationRangeCloud;
   std::vector<int> SegmentationCloud;
   std::vector<float> IntensityCloud;
   std::vector<int> LaserIndexCloud;
   TimeNano LastSimTime = 0;
+  TimeNano PointCloudTime = 0;
+  microsoft::projectairsim::Pose PointCloudPose;
 
-  void SaveImage();
   void SetUpCams();
   void SetupSceneCapture(UCameraComponent* CameraComponent,
                          float HorizontalAngle, float Width, float Height,
@@ -83,18 +83,11 @@ UCLASS() class UGPULidar : public UUnrealSensor {
   UPROPERTY() UMaterial* LidarIntensityMaterialStatic;
 
   uint32 HorizontalResolution;  // more like spherical horizontal width
-  uint32 LaserNums;             // more like spherical vertical height
-
   // Need camfrustrum as well?
   uint32 CamFrustrumWidth;
   uint32 CamFrustrumHeight;
 
-  FMatrix ProjectionMat;
-  FVector cam1loc;
-  FQuat cam1Rot;
-
   std::vector<FMatrix> CamRotationMats;
-  FSceneViewProjectionData Cam1ProjData;
 
   TSharedPtr<FLidarIntensitySceneViewExtension, ESPMode::ThreadSafe>
       IntensityExtension;

--- a/unreal/Blocks/Plugins/ProjectAirSim/Source/ProjectAirSim/Private/Sensors/LidarIntensitySceneViewExtension.cpp
+++ b/unreal/Blocks/Plugins/ProjectAirSim/Source/ProjectAirSim/Private/Sensors/LidarIntensitySceneViewExtension.cpp
@@ -268,6 +268,9 @@ void FLidarIntensitySceneViewExtension::PrePostProcessPass_RenderThread(
           }
 
           FMemory::Memcpy(LidarPointCloudData.data(), BufferData, CurrentSize);
+          LidarPointCloudTime = ReadbackMetadata[CurrentReadbackIndex].CaptureTime;
+          LidarPointCloudPose = ReadbackMetadata[CurrentReadbackIndex].LidarPose;
+          bHasUnreadLidarPointCloudData = true;
           CurrentReadback->Unlock();
       }
   }
@@ -294,37 +297,20 @@ void FLidarIntensitySceneViewExtension::PrePostProcessPass_RenderThread(
   PassParameters->PointCloudBuffer = PointCloudBufferUAV;
   PassParameters->HorizontalResolution = cachedParams.HorizontalResolution;
   PassParameters->LaserNums = cachedParams.LaserNums;
+  PassParameters->TotalPointCount = NumPoints;
   PassParameters->LaserRange = cachedParams.LaserRange;
   PassParameters->CurrentHorizontalAngleDeg =
       cachedParams.CurrentHorizontalAngleDeg;
   PassParameters->HorizontalFOV = cachedParams.HorizontalFOV;
-    // Forward the configured azimuth window so the compute pass uses the same
-    // FOV limits as the CPU-side sensor settings.
-    PassParameters->HorizontalFOVStartDeg = cachedParams.HorizontalFOVStartDeg;
-    PassParameters->HorizontalFOVEndDeg = cachedParams.HorizontalFOVEndDeg;
-  PassParameters->VerticalFOV = cachedParams.VerticalFOV;
+  // Forward the configured azimuth window so the compute pass uses the same
+  // FOV limits as the CPU-side sensor settings.
+  PassParameters->HorizontalFOVStartDeg = cachedParams.HorizontalFOVStartDeg;
+  PassParameters->HorizontalFOVEndDeg = cachedParams.HorizontalFOVEndDeg;
+  PassParameters->VerticalFOVUpperDeg = cachedParams.VerticalFOVUpperDeg;
+  PassParameters->VerticalFOVLowerDeg = cachedParams.VerticalFOVLowerDeg;
+  PassParameters->CameraHorizontalFOVDeg = cachedParams.CameraHorizontalFOVDeg;
   PassParameters->CamFrustrumHeight = cachedParams.CamFrustrumHeight;
   PassParameters->CamFrustrumWidth = cachedParams.CamFrustrumWidth;
-  PassParameters->ProjectionMatrixInv =
-      cachedParams.ViewProjectionMatInv.GetTransposed();
-
-  // Forward projection matrix used by the shader's ProjectWorldToScreen
-  // (spherical coords → screen). The spherical coord is camera-relative,
-  // so ViewOrigin = 0; the axis-swap rotation orients Unreal's world axes
-  // into the projection's view axes (z-forward). Transposed because HLSL
-  // mul(matrix, vector) treats the matrix as column-major.
-  {
-    FSceneViewProjectionData FwdProjData;
-    FwdProjData.ViewOrigin = FVector(0.f);
-    FwdProjData.ViewRotationMatrix =
-        FMatrix(FPlane(0, 0, 1, 0), FPlane(1, 0, 0, 0), FPlane(0, 1, 0, 0),
-                FPlane(0, 0, 0, 1));
-    FwdProjData.ProjectionMatrix = cachedParams.ProjectionMat;
-    FwdProjData.SetConstrainedViewRectangle(FIntRect(
-        0, 0, cachedParams.CamFrustrumWidth, cachedParams.CamFrustrumHeight));
-    PassParameters->ProjectionMatrix =
-        FMatrix44f(FwdProjData.ComputeViewProjectionMatrix().GetTransposed());
-  }
 
   PassParameters->CamRotationMatrix1 = cachedParams.RotationMatCam1;
   PassParameters->CamRotationMatrix2 = cachedParams.RotationMatCam2;
@@ -351,6 +337,7 @@ void FLidarIntensitySceneViewExtension::PrePostProcessPass_RenderThread(
 
   // Store the size for the next time we encounter this buffer slot
   ReadbackBuffersSizes[CurrentReadbackIndex] = BufferSize;
+  ReadbackMetadata[CurrentReadbackIndex] = cachedParams;
 
   // Advance index for next frame
   CurrentReadbackIndex = (CurrentReadbackIndex + 1) % NumReadbackBuffers;

--- a/unreal/Blocks/Plugins/ProjectAirSim/Source/ProjectAirSim/Private/Sensors/LidarIntensitySceneViewExtension.h
+++ b/unreal/Blocks/Plugins/ProjectAirSim/Source/ProjectAirSim/Private/Sensors/LidarIntensitySceneViewExtension.h
@@ -47,6 +47,9 @@ public:
   // (32 bytes), which mismatches the 16-byte-per-point layout the compute
   // shader writes and would cause silent stride misalignment.
   std::vector<FVector4f> LidarPointCloudData;
+  TimeNano LidarPointCloudTime = 0;
+  microsoft::projectairsim::Pose LidarPointCloudPose;
+  bool bHasUnreadLidarPointCloudData = false;
 
 private:
   std::queue<FLidarPointCloudCSParameters> CSParamsQ;
@@ -55,5 +58,6 @@ private:
   static constexpr int NumReadbackBuffers = 2;
   TUniquePtr<FRHIGPUBufferReadback> ReadbackBuffers[NumReadbackBuffers];
   uint32 ReadbackBuffersSizes[NumReadbackBuffers] = {};
+  FLidarPointCloudCSParameters ReadbackMetadata[NumReadbackBuffers];
   int CurrentReadbackIndex = 0;
 };

--- a/unreal/Blocks/Plugins/ProjectAirSim/Source/ProjectAirSim/Private/Sensors/LidarPointCloudCS.h
+++ b/unreal/Blocks/Plugins/ProjectAirSim/Source/ProjectAirSim/Private/Sensors/LidarPointCloudCS.h
@@ -16,6 +16,8 @@
 #include "Runtime/Engine/Classes/Engine/TextureRenderTarget2D.h"
 #include "ShaderParameterStruct.h"
 #include "UnrealCameraRenderRequest.h"
+#include "core_sim/clock.hpp"
+#include "core_sim/physics_common_types.hpp"
 
 #define NUM_THREADS_PER_GROUP_DIMENSION_X 1024
 #define NUM_THREADS_PER_GROUP_DIMENSION_Y 1
@@ -48,18 +50,18 @@ class FLidarPointCloudCS : public FGlobalShader {
   SHADER_PARAMETER(FMatrix44f, CamRotationMatrix4)
   SHADER_PARAMETER(unsigned int, HorizontalResolution)
   SHADER_PARAMETER(unsigned int, LaserNums)
+  SHADER_PARAMETER(unsigned int, TotalPointCount)
   SHADER_PARAMETER(float, LaserRange)
   SHADER_PARAMETER(float, HorizontalFOV)
   SHADER_PARAMETER(float, HorizontalFOVStartDeg)
   SHADER_PARAMETER(float, HorizontalFOVEndDeg)
   SHADER_PARAMETER(float, CurrentHorizontalAngleDeg)
-  SHADER_PARAMETER(float, VerticalFOV)
+  SHADER_PARAMETER(float, VerticalFOVUpperDeg)
+  SHADER_PARAMETER(float, VerticalFOVLowerDeg)
+  SHADER_PARAMETER(float, CameraHorizontalFOVDeg)
   SHADER_PARAMETER(unsigned int, CamFrustrumWidth)
   SHADER_PARAMETER(unsigned int, CamFrustrumHeight)
-  SHADER_PARAMETER(FMatrix44f, ProjectionMatrix)
-  SHADER_PARAMETER(FMatrix44f, ProjectionMatrixInv)
   SHADER_PARAMETER_RDG_BUFFER_UAV(RWStructuredBuffer<float>, PointCloudBuffer)
-  // SHADER_PARAMETER_UAV(RWStructuredBuffer<float>, PointCloudBuffer)
   END_SHADER_PARAMETER_STRUCT()
 
  public:
@@ -117,10 +119,12 @@ struct FLidarPointCloudCSParameters {
   // reject rays outside a partial-FOV sensor setup.
   float HorizontalFOVStartDeg;
   float HorizontalFOVEndDeg;
-  float VerticalFOV;
-
-  FMatrix ProjectionMat;
-  FMatrix44f ViewProjectionMatInv;
+  float VerticalFOVUpperDeg;
+  float VerticalFOVLowerDeg;
+  float CameraHorizontalFOVDeg;
 
   int NumCams = 1;
+
+  TimeNano CaptureTime = 0;
+  microsoft::projectairsim::Pose LidarPose;
 };

--- a/unreal/Blocks/Plugins/ProjectAirSim/Source/ProjectAirSim/Private/Shaders/LidarPointCloudCS.usf
+++ b/unreal/Blocks/Plugins/ProjectAirSim/Source/ProjectAirSim/Private/Shaders/LidarPointCloudCS.usf
@@ -19,47 +19,47 @@ float4x4 CamRotationMatrix4;
 
 uint HorizontalResolution;
 uint LaserNums;
+uint TotalPointCount;
 float LaserRange;
 float CurrentHorizontalAngleDeg;
 
 float HorizontalFOV;
 float HorizontalFOVStartDeg;
 float HorizontalFOVEndDeg;
-float VerticalFOV;
+float VerticalFOVUpperDeg;
+float VerticalFOVLowerDeg;
+float CameraHorizontalFOVDeg;
 uint CamFrustrumWidth;
 uint CamFrustrumHeight;
 
-float4x4 ProjectionMatrix;
-float4x4 ProjectionMatrixInv;
-
 RWStructuredBuffer<float> PointCloudBuffer; // output of this shader
 
-bool ProjectWorldToScreen(float4 WorldPosition, out float2 ScreenPos)
+bool ProjectCameraRayToScreen(float3 CamRayDir, out uint2 ScreenPos)
 {
-    float4 Result = mul(ProjectionMatrix, WorldPosition);
-    if (Result.w > 0.0)
+    ScreenPos = uint2(0, 0);
+
+    if (CamRayDir.x <= 0.00001)
     {
-        float RHW = 1.0f / Result.w;
-        float4 PosInScreenSpace =
-        float4(Result.x * RHW, Result.y * RHW, Result.z * RHW, Result.w);
-
-		// Move from projection space to normalized 0..1 UI space
-        float NormalizedX = (PosInScreenSpace.x / 2.f) + 0.5f;
-        float NormalizedY = 1.f - (PosInScreenSpace.y / 2.f) - 0.5f;
-
-        ScreenPos = float2((NormalizedX * float(CamFrustrumWidth)),
-                                    (NormalizedY * float(CamFrustrumHeight)));
-		
-        if (ScreenPos.x > CamFrustrumWidth || ScreenPos.x < 0.f || ScreenPos.y > CamFrustrumHeight ||
-        ScreenPos.y < 0.f)
-        {
-            return false;
-        }
-
-        return true;
+        return false;
     }
-	
-    return false;
+
+    float tanHalfHorizontalFOV = tan(radians(CameraHorizontalFOVDeg * 0.5));
+    float aspectRatio = float(CamFrustrumWidth) / float(CamFrustrumHeight);
+    float tanHalfVerticalFOV = tanHalfHorizontalFOV / aspectRatio;
+
+    float normalizedX = (CamRayDir.y / CamRayDir.x) / tanHalfHorizontalFOV;
+    float normalizedY = (CamRayDir.z / CamRayDir.x) / tanHalfVerticalFOV;
+
+    if (normalizedX < -1.0 || normalizedX > 1.0 ||
+        normalizedY < -1.0 || normalizedY > 1.0)
+    {
+        return false;
+    }
+
+    float pixelX = (normalizedX * 0.5 + 0.5) * float(CamFrustrumWidth - 1);
+    float pixelY = (0.5 - normalizedY * 0.5) * float(CamFrustrumHeight - 1);
+    ScreenPos = uint2(uint(round(pixelX)), uint(round(pixelY)));
+    return true;
 }
 
 bool IsAngleInRange(float Angle, float StartAngle,
@@ -110,18 +110,19 @@ float ReadDepthByCam(int camIndex, uint2 screencoords)
     return DepthImage4[screencoords].r;
 }
 
-bool ProjectSphericalCoords(int camIndex, int projectionIndex, out uint2 ScreenPos)
+bool ProjectSphericalCoords(int camIndex, int projectionIndex, out uint2 ScreenPos,
+                            out float3 SensorRayDir, out float3 CamRayDir)
 {
+    ScreenPos = uint2(0, 0);
+    SensorRayDir = float3(0.0, 0.0, 0.0);
+    CamRayDir = float3(0.0, 0.0, 0.0);
+
     float AngleDistanceOfLaserMeasureDeg = HorizontalFOV / HorizontalResolution;
 
-    float vertical_fov_upper_deg = VerticalFOV / 2.0; // max: 15.0;
-    float vertical_fov_lower_deg = -vertical_fov_upper_deg;
-	//float CurrentHorizontalAngleDeg = 90.0 - (HorizontalFOV / 2.0); // assumes camera FOV of 90
-	
     float DeltaAngleDeg = 0;
     if (LaserNums > 1)
     {
-        DeltaAngleDeg = (vertical_fov_upper_deg - vertical_fov_lower_deg) /
+        DeltaAngleDeg = (VerticalFOVUpperDeg - VerticalFOVLowerDeg) /
                     float(LaserNums - 1);
     }
 	
@@ -130,7 +131,7 @@ bool ProjectSphericalCoords(int camIndex, int projectionIndex, out uint2 ScreenP
 
     float HorizontalAngleDeg = (CurrentHorizontalAngleDeg +
                       AngleDistanceOfLaserMeasureDeg * horizontal_angle_idx) % 360.0;
-    float VerticalAngleDeg = vertical_fov_upper_deg - float(vertical_angle_idx) * DeltaAngleDeg;
+    float VerticalAngleDeg = VerticalFOVUpperDeg - float(vertical_angle_idx) * DeltaAngleDeg;
 	
     // Respect the configured horizontal window before projecting into a camera.
     if (!IsAngleInRange(HorizontalAngleDeg, HorizontalFOVStartDeg, HorizontalFOVEndDeg))
@@ -141,74 +142,22 @@ bool ProjectSphericalCoords(int camIndex, int projectionIndex, out uint2 ScreenP
     float horRad = radians(HorizontalAngleDeg);
     float verRad = radians(VerticalAngleDeg);
 	
-    float3 vecFromSphericalCoord = float3(sin(horRad), cos(horRad), sin(verRad));
+    // Match Unreal's FRotator(Pitch=elevation, Yaw=azimuth).Vector():
+    // yaw 0 points forward along +X, yaw 90 points right along +Y.
+    float cosVer = cos(verRad);
+    float3 vecFromSphericalCoord = float3(
+        cosVer * cos(horRad),
+        cosVer * sin(horRad),
+        sin(verRad));
+    SensorRayDir = normalize(vecFromSphericalCoord);
 
     // Rotate the ray from sensor space into the local frame of the camera that
-    // captured this sector so the screen projection stays consistent.
+    // captured this sector. These FMatrix values arrive in shader layout such
+    // that using the matrix directly applies the inverse camera rotation.
     float4x4 CamRotation = GetCamRotationMatrix(camIndex);
-    float3 vecInCamFrame = mul((float3x3)transpose(CamRotation), vecFromSphericalCoord);
+    CamRayDir = normalize(mul((float3x3)CamRotation, SensorRayDir));
 
-    float4 HVecFromSphericalCoord = float4(0.0, 0.0, 0.0, 1.0);
-    if (length(HVecFromSphericalCoord) > 0.00001)
-    {
-		// multiply by any number past the near plane (> 10)
-        HVecFromSphericalCoord.xyz = normalize(vecInCamFrame) * 50.0;
-    }
-	
-    return ProjectWorldToScreen(HVecFromSphericalCoord, ScreenPos);
-}
-
-float3 DeprojectScreenToWorld(float4x4 ProjectionMatrixInv, uint2 screenpos, float depth)
-{
-    float pixelX = float(screenpos.x);
-    float pixelY = float(screenpos.y);
-
-    // pixel coord to 0 to 1 space
-    float normX = pixelX / CamFrustrumWidth;
-    float normY = pixelY / CamFrustrumHeight;
-
-    // pixel coord to -1 to 1 space
-    float ndcX = (normX - .5) * 2.0;
-    float ndcY = ((1.0 - normY) - .5) * 2.0;
-
-    // The start of the ray trace is defined to be at mousex,mousey,1 in
-    // projection space (z=1 is near, z=0 is far - this gives us better precision)
-    // To get the direction of the ray trace we need to use any z between the near
-    // and the far plane, so let's use (mousex, mousey, 0.001)
-    float4 rayStartProjectionSpace = float4(ndcX, ndcY, 1.0, 1.0);
-    float4 rayEndProjectionSpace = float4(ndcX, ndcY, 0.001, 1.0);
-    
-    float4 hgRayStartWorldSpace = mul(ProjectionMatrixInv, rayStartProjectionSpace);
-    float4 hgRayEndWorldSpace = mul(ProjectionMatrixInv, rayEndProjectionSpace);
-
-    float3 rayStartWorldSpace = hgRayStartWorldSpace.xyz;
-    float3 rayEndWorldSpace = hgRayEndWorldSpace.xyz;
-    if (hgRayStartWorldSpace.w != 0.0)
-    {
-        rayStartWorldSpace /= hgRayStartWorldSpace.w;
-    }
-    if (hgRayEndWorldSpace.w != 0.0)
-    {
-        rayEndWorldSpace /= hgRayEndWorldSpace.w;
-    }
-
-    float3 rayDirection = rayEndWorldSpace - rayStartWorldSpace;
-    float3 camForward = float3(1.0, 0.0, 0.0); // TODO: parameterize (this is only for cam1)
-    float3 nearPlaneOffset = float3(10.0, 0.0, 0.0);
-    float3 camPos = rayStartWorldSpace - nearPlaneOffset;
-    // add rotation matrix also.. // probably multiply by rotation (or would it be inverse?)
-    
-    float dotProd = dot(rayDirection, camForward);
-    if (abs(dotProd) < 0.00001)
-    {
-        return rayStartProjectionSpace.xyz;
-    }
-    return camPos + depth * (rayDirection / dotProd);
-}
-
-float3 ToNEDMeters(float3 neu_cm)
-{
-    return float3(neu_cm.x, neu_cm.y, -neu_cm.z) * 100.0;
+    return ProjectCameraRayToScreen(CamRayDir, ScreenPos);
 }
 
 [numthreads(THREADGROUPSIZE_X, THREADGROUPSIZE_Y, THREADGROUPSIZE_Z)]
@@ -217,13 +166,25 @@ void MainComputeShader(uint3 Gid : SV_GroupID, //atm: -, 0...256, - in rows (Y) 
                        uint3 GTid : SV_GroupThreadID, //atm: 0...256, -,- in columns (X)      --> current threadId in group / "local" threadId
                        uint GI : SV_GroupIndex)            //atm: 0...256 in columns (X)           --> "flattened" index of a thread within a group)
 {
-    int gtid = DTid.x;
-    int pointIndex = gtid * 4;
+    uint gtid = DTid.x;
+    if (gtid >= TotalPointCount)
+    {
+        return;
+    }
 
-    int camIndex = gtid / (HorizontalResolution * LaserNums);
-    int projectionIndex = gtid % (HorizontalResolution * LaserNums);
+    uint pointIndex = gtid * 4;
+    PointCloudBuffer[pointIndex + 0] = -1.0;
+    PointCloudBuffer[pointIndex + 1] = -1.0;
+    PointCloudBuffer[pointIndex + 2] = -1.0;
+    PointCloudBuffer[pointIndex + 3] = 0.0;
+
+    int camIndex = int(gtid / (HorizontalResolution * LaserNums));
+    int projectionIndex = int(gtid % (HorizontalResolution * LaserNums));
     uint2 screencoords;
-    bool inScreen = ProjectSphericalCoords(camIndex, projectionIndex, screencoords);
+    float3 sensorRayDir;
+    float3 camRayDir;
+    bool inScreen = ProjectSphericalCoords(camIndex, projectionIndex, screencoords,
+                                           sensorRayDir, camRayDir);
     float intensity = 1.0;
 
     if (inScreen)
@@ -232,7 +193,8 @@ void MainComputeShader(uint3 Gid : SV_GroupID, //atm: -, 0...256, - in rows (Y) 
         // single forward-facing render target.
         float depthD1 = ReadDepthByCam(camIndex, screencoords);
 		
-        if (depthD1 > LaserRange)
+        float depthAlongCameraForward = dot(camRayDir, float3(1.0, 0.0, 0.0));
+        if (depthD1 > LaserRange || depthAlongCameraForward <= 0.00001)
         {
             PointCloudBuffer[pointIndex + 0] = -1.0;
             PointCloudBuffer[pointIndex + 1] = -1.0;
@@ -241,11 +203,19 @@ void MainComputeShader(uint3 Gid : SV_GroupID, //atm: -, 0...256, - in rows (Y) 
         }
         else
         {
-		// TODO: now that we're doing projection here too, we could keep the ray dir and pass here
-            float3 pc = DeprojectScreenToWorld(ProjectionMatrixInv, screencoords, depthD1);
-            // Convert the hit back from the camera-local frame into the shared
-            // lidar sensor frame before publishing the point cloud.
-            float3 pcSensor = mul((float3x3)GetCamRotationMatrix(camIndex), pc);
+            // SceneDepth is planar depth along the active camera's forward axis.
+            // Reconstruct along the same ray that was projected into that camera,
+            // then publish the point directly in the shared lidar sensor frame.
+            float radialDepth = depthD1 / depthAlongCameraForward;
+            float3 pcSensor = sensorRayDir * radialDepth;
+            if (radialDepth > LaserRange)
+            {
+                PointCloudBuffer[pointIndex + 0] = -1.0;
+                PointCloudBuffer[pointIndex + 1] = -1.0;
+                PointCloudBuffer[pointIndex + 2] = -1.0;
+                PointCloudBuffer[pointIndex + 3] = intensity;
+                return;
+            }
             PointCloudBuffer[pointIndex + 0] = pcSensor.x;
             PointCloudBuffer[pointIndex + 1] = pcSensor.y;
             PointCloudBuffer[pointIndex + 2] = pcSensor.z;


### PR DESCRIPTION
## Overview

This PR fixes a lidar bug related to data mapping into space coordinates.

## Modifications

- Modified lidar parameters of `robot_quadrotor_fastphysics_lidar.jsonc` for testing purposes
- Implemented `LidarTopDownRenderer` to visualize lidar scans in ubuntu
- Added cameras for testing in jsonc files

## Shader/GPU modifications
- Fixed GPU shader horizontal-angle convention mismatch
- Fixed GPU shader angle mapping mismatch
- Deprojection is no longer cam-1-centric
- Fixed async readback/pose mismatch
- Fixed partial FOV normalization

## Before this PR
[output_gpu.webm](https://github.com/user-attachments/assets/f5d73189-4782-4017-b98f-e1302c3eb862)


## After this PR
<img width="638" height="662" alt="latest_gpu-ezgif com-crop" src="https://github.com/user-attachments/assets/2a200441-ee9d-49f2-ad99-07f336e48205" />
