### PR TITLE
Remove deprecated pkg_resources fallback from resource loading

### DIFF
--- a/client/python/projectairsim/pyproject.toml
+++ b/client/python/projectairsim/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
 ]
 
 dependencies = [
+  "importlib-resources>=5; python_version<'3.9'",
   "pynng>=0.5.0",
   "msgpack>=1.0.5",
   "opencv-python>=4.2.0.32",

--- a/client/python/projectairsim/src/projectairsim/utils.py
+++ b/client/python/projectairsim/src/projectairsim/utils.py
@@ -8,7 +8,12 @@ ProjectAirSim utilities
 import logging
 import math
 from typing import Dict, List, Tuple
-import importlib.resources as resources
+
+try:
+    from importlib.resources import files
+except ImportError:  # Python < 3.9
+    from importlib_resources import files
+
 import msgpack
 import numpy as np
 import collections
@@ -25,20 +30,14 @@ from projectairsim.geodetic_converter import GeodeticConverter
 def load_text_resource(resource_path: str) -> str:
     """Loads a package text resource and returns its contents.
 
-    Uses importlib.resources.files() when available (Python >= 3.9).
-    Falls back to pkg_resources for older Python versions.
+    Uses importlib.resources.files() on Python >= 3.9 and the
+    importlib-resources backport on older supported Python versions.
     """
-    if hasattr(resources, "files"):
-        # Preferred API: importlib.resources.files() (Python >= 3.9)
-        return (
-            resources.files(__package__)
-            .joinpath(resource_path)
-            .read_text(encoding="utf-8")
-        )
-    # Compatibility fallback for Python < 3.9
-    import pkg_resources
-
-    return pkg_resources.resource_string(__package__, resource_path).decode("utf-8")
+    return (
+        files(__package__)
+        .joinpath(*resource_path.split("/"))
+        .read_text(encoding="utf-8")
+    )
 
 
 def get_pitch_between_traj_points(point1, point2):


### PR DESCRIPTION
## Summary
- remove the deprecated `pkg_resources` fallback in `projectairsim.utils.load_text_resource`
- always use `importlib.resources.files()`, with the maintained `importlib-resources` backport on Python <3.9
- join nested resource paths with `joinpath(*resource_path.split("/"))`

## Motivation
This is a maintenance and compatibility change. Current `main` already prefers `importlib.resources.files()` on Python >=3.9, so the `pkg_resources` branch is not normally reached on Python 3.14. Removing it still drops a deprecated runtime dependency on setuptools/`pkg_resources` and keeps schema loading working on environments that no longer ship `pkg_resources` by default.

## Verification
- `python3 -m compileall -q client/python/projectairsim/src/projectairsim/utils.py`
- isolated Python 3.14 resource-load check for `schema/robot_config_schema.jsonc`, confirming `pkg_resources` is not imported
- `git diff --check -- client/python/projectairsim/src/projectairsim/utils.py client/python/projectairsim/pyproject.toml`

Full package import was not run because this local Python 3.14 environment does not have the package runtime dependencies installed (`msgpack` fails first).