### PR TITLE
Optimize actuator control signal retrieval

### DIFF
--- a/core_sim/include/core_sim/actuators/actuator.hpp
+++ b/core_sim/include/core_sim/actuators/actuator.hpp
@@ -6,6 +6,7 @@
 #ifndef CORE_SIM_INCLUDE_CORE_SIM_ACTUATORS_ACTUATOR_HPP_
 #define CORE_SIM_INCLUDE_CORE_SIM_ACTUATORS_ACTUATOR_HPP_
 
+#include <array>
 #include <memory>
 #include <string>
 #include <vector>
@@ -29,17 +30,23 @@ enum class ActuatorType {
 // Abstract base class
 class Actuator {
  public:
+  static constexpr size_t kMaxControlSignalCount = 3;
+  using ControlSignals = std::array<float, kMaxControlSignalCount>;
+
   virtual ~Actuator() {}
 
   bool IsLoaded() const;
 
   const std::string& GetId() const;
+  size_t GetSignalCount() const;
+  int GetSignalIndex(size_t signal_offset = 0) const;
+  void SetSignalIndex(int signal_index, size_t signal_offset = 0);
   ActuatorType GetType() const;
   bool IsEnabled() const;
   const std::string& GetParentLink() const;
   const std::string& GetChildLink() const;
-  virtual void UpdateActuatorOutput(std::vector<float> && control_signals,
-                            const TimeNano sim_dt_nanos) = 0;
+  virtual void UpdateActuatorOutput(const ControlSignals& control_signals,
+                                    const TimeNano sim_dt_nanos) = 0;
 
   bool UpdateFaultInjectionEnabledState(bool enabled);
 

--- a/core_sim/include/core_sim/actuators/gimbal.hpp
+++ b/core_sim/include/core_sim/actuators/gimbal.hpp
@@ -37,7 +37,7 @@ class Gimbal : public Actuator {
 
   const ActuatedTransforms& GetActuatedTransforms() const;
 
- void UpdateActuatorOutput(std::vector<float> && control_signals,
+  void UpdateActuatorOutput(const ControlSignals& control_signals,
                             const TimeNano sim_dt_nanos) override;
 
   const std::string& GetTargetID(void) const;

--- a/core_sim/include/core_sim/actuators/lift_drag_control_surface.hpp
+++ b/core_sim/include/core_sim/actuators/lift_drag_control_surface.hpp
@@ -43,8 +43,8 @@ class LiftDragControlSurface : public Actuator {
 
   const float& GetControlAngle() const;
 
- void UpdateActuatorOutput(std::vector<float> && control_signals,
-                            const TimeNano sim_dt_nanos)override;
+  void UpdateActuatorOutput(const ControlSignals& control_signals,
+                            const TimeNano sim_dt_nanos) override;
 
  private:
   friend class Robot;

--- a/core_sim/include/core_sim/actuators/rotor.hpp
+++ b/core_sim/include/core_sim/actuators/rotor.hpp
@@ -112,8 +112,8 @@ class Rotor : public Actuator {
 
   void SetTilt(Quaternion quat);
 
- void UpdateActuatorOutput(std::vector<float> && control_signals,
-                            const TimeNano sim_dt_nanos)override;
+  void UpdateActuatorOutput(const ControlSignals& control_signals,
+                            const TimeNano sim_dt_nanos) override;
 
   // These conversion operators allow this object to be passed directly to
   // TransformTree methods

--- a/core_sim/include/core_sim/actuators/tilt.hpp
+++ b/core_sim/include/core_sim/actuators/tilt.hpp
@@ -52,7 +52,7 @@ class Tilt : public Actuator {
 
   const std::string& GetTargetID(void) const;
 
- void UpdateActuatorOutput(std::vector<float> && control_signals,
+  void UpdateActuatorOutput(const ControlSignals& control_signals,
                             const TimeNano sim_dt_nanos) override;
 
  private:

--- a/core_sim/include/core_sim/actuators/wheel.hpp
+++ b/core_sim/include/core_sim/actuators/wheel.hpp
@@ -96,7 +96,7 @@ class Wheel : public Actuator {
 
   const float GetPowerConsumption() const;
 
-  void UpdateActuatorOutput(std::vector<float>&& control_signals,
+  void UpdateActuatorOutput(const ControlSignals& control_signals,
                             const TimeNano sim_dt_nanos) override;
 
   // These conversion operators allow this object to be passed directly to

--- a/core_sim/include/core_sim/runtime_components.hpp
+++ b/core_sim/include/core_sim/runtime_components.hpp
@@ -52,6 +52,18 @@ class IController : public IRuntimeComponent {
   // TODO: Should this be in the base IRuntimeComponent?
   virtual void Update() = 0;
 
+  virtual int GetControlSignalIndex(const std::string& actuator_id) = 0;
+
+  virtual int GetControlSignalIndex(const std::string& actuator_id,
+                                    size_t signal_offset) {
+    return signal_offset == 0 ? GetControlSignalIndex(actuator_id) : -1;
+  }
+
+  virtual void GetControlSignalSnapshot(
+      std::vector<float>& control_signals) = 0;
+
+  virtual std::vector<float> GetControlSignals(int signal_index) = 0;
+
   virtual std::vector<float> GetControlSignals(const std::string& actuator_id) = 0;
 
   virtual const GimbalState& GetGimbalSignal(const std::string& gimbal_id) = 0;

--- a/core_sim/src/actor/robot.cpp
+++ b/core_sim/src/actor/robot.cpp
@@ -198,6 +198,7 @@ class Robot::Impl : public ActorImpl {
   float total_power_ = 0.0f;
 
   std::unique_ptr<IController> controller_;
+  std::vector<float> control_signal_snapshot_;
 
   std::vector<std::unique_ptr<Actuator>> actuators_;
   std::vector<std::reference_wrapper<Actuator>> actuators_ref_;
@@ -742,6 +743,18 @@ bool Robot::Impl::SetGroundTruthKinematics(
 }
 
 void Robot::Impl::SetController(std::unique_ptr<IController> controller) {
+  for (auto& actuator : actuators_) {
+    if (actuator->GetType() != ActuatorType::kGimbal) {
+      for (size_t signal_offset = 0; signal_offset < actuator->GetSignalCount();
+           ++signal_offset) {
+        const int signal_index = controller == nullptr
+                                     ? -1
+                                     : controller->GetControlSignalIndex(
+                                           actuator->GetId(), signal_offset);
+        actuator->SetSignalIndex(signal_index, signal_offset);
+      }
+    }
+  }
   controller_ = std::move(controller);
 }
 
@@ -1056,16 +1069,29 @@ void Robot::Impl::UpdateActuators(const TimeNano sim_time,
                                   const TimeNano sim_dt_nanos) {
   std::lock_guard<std::mutex> lock(update_lock_);
 
-  if (actuators_.empty()) return;
+  if (actuators_.empty() || controller_ == nullptr) return;
+
+  controller_->GetControlSignalSnapshot(control_signal_snapshot_);
+  const auto get_control_signals =
+      [this](const Actuator& actuator) -> Actuator::ControlSignals {
+    Actuator::ControlSignals control_signals = {};
+    for (size_t signal_offset = 0; signal_offset < actuator.GetSignalCount();
+         ++signal_offset) {
+      const int signal_index = actuator.GetSignalIndex(signal_offset);
+      if (signal_index >= 0 &&
+          signal_index < static_cast<int>(control_signal_snapshot_.size())) {
+        control_signals[signal_offset] = control_signal_snapshot_[signal_index];
+      }
+    }
+    return control_signals;
+  };
 
   // Update tilt actuator first since they affect other actuators
   for (auto& actuator : actuators_) {
     if (actuator->GetType() == ActuatorType::kTilt) {
       // Call actuator to update its output for its current control signal
-      std::vector<float> control_signals =
-          controller_->GetControlSignals(actuator->GetId());
-
-      actuator->UpdateActuatorOutput(std::move(control_signals), sim_dt_nanos);
+      actuator->UpdateActuatorOutput(get_control_signals(*actuator),
+                                     sim_dt_nanos);
     }
   }
 
@@ -1096,10 +1122,8 @@ void Robot::Impl::UpdateActuators(const TimeNano sim_time,
       }
 
       // Call actuator to update its output for its current control signal
-      std::vector<float> control_signals =
-          controller_->GetControlSignals(actuator->GetId());
-
-      actuator->UpdateActuatorOutput(std::move(control_signals), sim_dt_nanos);
+      actuator->UpdateActuatorOutput(get_control_signals(*actuator),
+                                     sim_dt_nanos);
     }
 
     // Do post-processing specific to actuator type

--- a/core_sim/src/actuators/actuator.cpp
+++ b/core_sim/src/actuators/actuator.cpp
@@ -23,6 +23,16 @@ ActuatorType Actuator::GetType() const { return pimpl_->GetType(); }
 
 const std::string& Actuator::GetId() const { return pimpl_->GetID(); }
 
+size_t Actuator::GetSignalCount() const { return pimpl_->GetSignalCount(); }
+
+int Actuator::GetSignalIndex(size_t signal_offset) const {
+  return pimpl_->GetSignalIndex(signal_offset);
+}
+
+void Actuator::SetSignalIndex(int signal_index, size_t signal_offset) {
+  pimpl_->SetSignalIndex(signal_index, signal_offset);
+}
+
 bool Actuator::IsEnabled() const { return pimpl_->IsEnabled(); }
 
 const std::string& Actuator::GetParentLink() const {

--- a/core_sim/src/actuators/actuator_impl.hpp
+++ b/core_sim/src/actuators/actuator_impl.hpp
@@ -43,7 +43,8 @@ class ActuatorImpl : public ComponentWithTopicsAndServiceMethods {
         type_(type),
         enabled_(enabled),
         parent_link_(parent_link),
-        child_link_(child_link) {}
+        child_link_(child_link),
+        signal_indices_({-1, -1, -1}) {}
 
   const bool IsEnabled() const { return enabled_; }
 
@@ -52,6 +53,18 @@ class ActuatorImpl : public ComponentWithTopicsAndServiceMethods {
   const std::string& GetParentLink() const { return parent_link_; }
 
   const std::string& GetChildLink() const { return child_link_; }
+
+  size_t GetSignalCount() const {
+    return type_ == ActuatorType::kWheel ? 3 : 1;
+  }
+
+  int GetSignalIndex(size_t signal_offset) const {
+    return signal_indices_.at(signal_offset);
+  }
+
+  void SetSignalIndex(int signal_index, size_t signal_offset) {
+    signal_indices_.at(signal_offset) = signal_index;
+  }
 
   bool UpdateFaultInjectionEnabledState(bool enabled) {
     is_fault_injected_ = enabled;
@@ -255,6 +268,7 @@ class ActuatorImpl : public ComponentWithTopicsAndServiceMethods {
   bool enabled_;
   std::string parent_link_;
   std::string child_link_;
+  std::array<int, Actuator::kMaxControlSignalCount> signal_indices_;
 };
 
 }  // namespace projectairsim

--- a/core_sim/src/actuators/gimbal.cpp
+++ b/core_sim/src/actuators/gimbal.cpp
@@ -56,7 +56,7 @@ class Gimbal::Impl : public ActuatorImpl {
 
   const ActuatedTransforms& GetActuatedTransforms() const;
 
-   void UpdateActuatorOutput(std::vector<float> && control_signals,
+  void UpdateActuatorOutput(const ControlSignals& control_signals,
                             const TimeNano sim_dt_nanos);
 
   void UpdateGimbal(IController::GimbalState& new_state,
@@ -118,9 +118,10 @@ const IController::GimbalState& Gimbal::GetGimbalState() const {
   return static_cast<Gimbal::Impl*>(pimpl_.get())->GetGimbalState();
 };
 
-void Gimbal::UpdateActuatorOutput(std::vector<float> && control_signals, const TimeNano sim_dt_nanos){
+void Gimbal::UpdateActuatorOutput(const ControlSignals& control_signals,
+                                  const TimeNano sim_dt_nanos) {
   static_cast<Gimbal::Impl*>(pimpl_.get())
-      ->UpdateActuatorOutput(std::move(control_signals), sim_dt_nanos);
+      ->UpdateActuatorOutput(control_signals, sim_dt_nanos);
 }
 
 //------------------------------------------------------------------------------
@@ -191,7 +192,8 @@ void Gimbal::Impl::UpdateGimbal(IController::GimbalState& new_state,
   }
 }
 
-void Gimbal::Impl::UpdateActuatorOutput(std::vector<float> && control_signals, const TimeNano sim_dt_nanos) {
+void Gimbal::Impl::UpdateActuatorOutput(const ControlSignals& control_signals,
+                                        const TimeNano sim_dt_nanos) {
   return;
 }
 

--- a/core_sim/src/actuators/lift_drag_control_surface.cpp
+++ b/core_sim/src/actuators/lift_drag_control_surface.cpp
@@ -57,7 +57,8 @@ class LiftDragControlSurface::Impl : public ActuatorImpl {
 
   const float& GetControlAngle() const;
 
-  void UpdateActuatorOutput(std::vector<float> && control_signals, const TimeNano sim_dt_nanos);
+  void UpdateActuatorOutput(const ControlSignals& control_signals,
+                            const TimeNano sim_dt_nanos);
 
  private:
   friend class LiftDragControlSurface::Loader;
@@ -111,10 +112,10 @@ const float& LiftDragControlSurface::GetControlAngle() const {
       ->GetControlAngle();
 }
 
-void LiftDragControlSurface::UpdateActuatorOutput(std::vector<float> && control_signals,
-  const TimeNano sim_dt_nanos){
+void LiftDragControlSurface::UpdateActuatorOutput(
+    const ControlSignals& control_signals, const TimeNano sim_dt_nanos) {
   static_cast<LiftDragControlSurface::Impl*>(pimpl_.get())
-      ->UpdateActuatorOutput(std::move(control_signals), sim_dt_nanos);
+      ->UpdateActuatorOutput(control_signals, sim_dt_nanos);
 }
 
 //------------------------------------------------------------------------------
@@ -156,8 +157,8 @@ const float& LiftDragControlSurface::Impl::GetControlAngle() const {
   return control_angle_;
 }
 
-void LiftDragControlSurface::Impl::UpdateActuatorOutput(std::vector<float> && control_signals,
-  const TimeNano sim_dt_nanos){
+void LiftDragControlSurface::Impl::UpdateActuatorOutput(
+    const ControlSignals& control_signals, const TimeNano sim_dt_nanos) {
   // Convert -1.0 ~ +1.0 control signal to control surface angle (like a servo
   // motor but without any dynamics)
   auto control_signal = control_signals[0];

--- a/core_sim/src/actuators/rotor.cpp
+++ b/core_sim/src/actuators/rotor.cpp
@@ -75,7 +75,7 @@ class Rotor::Impl : public ActuatorImpl {
 
   const float GetPowerConsumption() const;
 
-  void UpdateActuatorOutput(std::vector<float> && control_signals,
+  void UpdateActuatorOutput(const ControlSignals& control_signals,
                             const TimeNano sim_dt_nanos);
 
   void SetAirDensityRatio(float air_density_ratio);
@@ -174,10 +174,10 @@ const ActuatedTransforms& Rotor::GetActuatedTransforms() const {
   return static_cast<Rotor::Impl*>(pimpl_.get())->GetActuatedTransforms();
 }
 
-void Rotor::UpdateActuatorOutput(std::vector<float> && control_signals,
-                            const TimeNano sim_dt_nanos){
+void Rotor::UpdateActuatorOutput(const ControlSignals& control_signals,
+                                 const TimeNano sim_dt_nanos) {
   static_cast<Rotor::Impl*>(pimpl_.get())
-      ->UpdateActuatorOutput(std::move(control_signals), sim_dt_nanos);
+      ->UpdateActuatorOutput(control_signals, sim_dt_nanos);
 }
 
 void Rotor::SetAirDensityRatio(float air_density_ratio) {
@@ -285,8 +285,8 @@ void Rotor::Impl::SetAirDensityRatio(float air_density_ratio) {
 
 void Rotor::Impl::SetTilt(Quaternion quat) { quat_tilt_ = quat; }
 
-void Rotor::Impl::UpdateActuatorOutput(std::vector<float> && control_signals,
-                            const TimeNano sim_dt_nanos){
+void Rotor::Impl::UpdateActuatorOutput(const ControlSignals& control_signals,
+                                       const TimeNano sim_dt_nanos) {
   // This actuator uses one control signal
   auto control_signal = control_signals[0];
   // Apply first order filter to simulate actuator hardware dynamics

--- a/core_sim/src/actuators/tilt.cpp
+++ b/core_sim/src/actuators/tilt.cpp
@@ -62,7 +62,7 @@ class Tilt::Impl : public ActuatorImpl {
 
   const std::string& GetTargetID(void) const { return (settings_.target_id); }
 
-  void UpdateActuatorOutput(std::vector<float> && control_signals,
+  void UpdateActuatorOutput(const ControlSignals& control_signals,
                             const TimeNano sim_dt_nanos);
 
  private:
@@ -125,10 +125,10 @@ const std::string& Tilt::GetTargetID(void) const {
   return static_cast<Tilt::Impl*>(pimpl_.get())->GetTargetID();
 }
 
-void Tilt::UpdateActuatorOutput(std::vector<float> && control_signals,
-                            const TimeNano sim_dt_nanos){
+void Tilt::UpdateActuatorOutput(const ControlSignals& control_signals,
+                                const TimeNano sim_dt_nanos) {
   static_cast<Tilt::Impl*>(pimpl_.get())
-      -> UpdateActuatorOutput(std::move(control_signals), sim_dt_nanos);
+      ->UpdateActuatorOutput(control_signals, sim_dt_nanos);
 }
 
 //------------------------------------------------------------------------------
@@ -176,8 +176,8 @@ const ActuatedTransforms& Tilt::Impl::GetActuatedTransforms() const {
   return actuated_transforms_;
 }
 
-void Tilt::Impl::UpdateActuatorOutput(std::vector<float> && control_signals,
-                            const TimeNano sim_dt_nanos){
+void Tilt::Impl::UpdateActuatorOutput(const ControlSignals& control_signals,
+                                      const TimeNano sim_dt_nanos) {
   float radians;
   Quaternion quat;
 

--- a/core_sim/src/actuators/wheel.cpp
+++ b/core_sim/src/actuators/wheel.cpp
@@ -85,7 +85,7 @@ class Wheel::Impl : public ActuatorImpl {
 
   const float GetPowerConsumption() const;
 
-  void UpdateActuatorOutput(std::vector<float>&& control_signals,
+  void UpdateActuatorOutput(const ControlSignals& control_signals,
                             const TimeNano sim_dt_nanos);
 
   void SetTilt(Quaternion quat);
@@ -210,10 +210,10 @@ const ActuatedTransforms& Wheel::GetActuatedTransforms() const {
   return static_cast<Wheel::Impl*>(pimpl_.get())->GetActuatedTransforms();
 }
 
-void Wheel ::UpdateActuatorOutput(std::vector<float>&& control_signals,
+void Wheel ::UpdateActuatorOutput(const ControlSignals& control_signals,
                                   const TimeNano sim_dt_nanos) {
   static_cast<Wheel::Impl*>(pimpl_.get())
-      ->UpdateActuatorOutput(std::move(control_signals), sim_dt_nanos);
+      ->UpdateActuatorOutput(control_signals, sim_dt_nanos);
 }
 
 Wheel::operator TransformTree::RefFrame&(void) {
@@ -317,7 +317,7 @@ const ActuatedTransforms& Wheel::Impl::GetActuatedTransforms() const {
 
 const float Wheel::Impl::GetPowerConsumption() const { return power_; }
 
-void Wheel::Impl::UpdateActuatorOutput(std::vector<float>&& control_signals,
+void Wheel::Impl::UpdateActuatorOutput(const ControlSignals& control_signals,
                                        const TimeNano sim_dt_nanos) {
   // Getting the control signals necessary for movement
   auto engine_signal = (engine_connected_) ? control_signals[0] : 0;

--- a/core_sim/test/gtest_actuator.cpp
+++ b/core_sim/test/gtest_actuator.cpp
@@ -52,6 +52,49 @@ class Scene {  // : public ::testing::Test {
   }
 };
 
+class FakeController : public IController {
+ public:
+  void BeginUpdate() override {}
+  void EndUpdate() override {}
+  void Reset() override {}
+  void SetKinematics(const Kinematics* kinematics) override {}
+  void Update() override {}
+
+  int GetControlSignalIndex(const std::string& actuator_id) override {
+    return GetControlSignalIndex(actuator_id, 0);
+  }
+
+  int GetControlSignalIndex(const std::string& actuator_id,
+                            size_t signal_offset) override {
+    ++index_lookup_count;
+    last_actuator_id = actuator_id;
+    return 7 + static_cast<int>(signal_offset);
+  }
+
+  void GetControlSignalSnapshot(std::vector<float>& control_signals) override {
+    control_signals = {0.0f};
+  }
+
+  std::vector<float> GetControlSignals(int signal_index) override {
+    return {static_cast<float>(signal_index)};
+  }
+
+  std::vector<float> GetControlSignals(
+      const std::string& actuator_id) override {
+    return GetControlSignals(GetControlSignalIndex(actuator_id));
+  }
+
+  const GimbalState& GetGimbalSignal(const std::string& gimbal_id) override {
+    return gimbal_state_;
+  }
+
+  int index_lookup_count = 0;
+  std::string last_actuator_id;
+
+ private:
+  GimbalState gimbal_state_;
+};
+
 }  // namespace projectairsim
 }  // namespace microsoft
 
@@ -99,6 +142,42 @@ TEST(Actuator, LoadsOneActuator) {
   auto& actuators = robot.GetActuators();
   // Assert: check result from `EXPECT_EQ(actuators.size(), 1);`.
   EXPECT_EQ(actuators.size(), 1);
+}
+
+TEST(Actuator, CachesControllerSignalIndex) {
+  auto config_json = projectairsim::Scene::get_actuator_config();
+  auto robot = projectairsim::Scene::MakeRobot("TestRobot");
+  projectairsim::Scene::LoadRobot(robot, config_json);
+  auto controller = std::make_unique<projectairsim::FakeController>();
+  auto* controller_ptr = controller.get();
+
+  robot.SetController(std::move(controller));
+
+  auto& actuator = robot.GetActuators().at(0).get();
+  EXPECT_EQ(actuator.GetSignalIndex(), 7);
+  EXPECT_EQ(controller_ptr->index_lookup_count, 1);
+  EXPECT_EQ(controller_ptr->last_actuator_id, actuator.GetId());
+  EXPECT_EQ(controller_ptr->GetControlSignals(actuator.GetSignalIndex()).at(0),
+            7.0f);
+  EXPECT_EQ(controller_ptr->index_lookup_count, 1);
+}
+
+TEST(Actuator, CachesAllWheelSignalIndices) {
+  auto config_json = projectairsim::Scene::get_actuator_config();
+  config_json["actuators"][0]["type"] = "wheel";
+  auto robot = projectairsim::Scene::MakeRobot("TestRobot");
+  projectairsim::Scene::LoadRobot(robot, config_json);
+  auto controller = std::make_unique<projectairsim::FakeController>();
+  auto* controller_ptr = controller.get();
+
+  robot.SetController(std::move(controller));
+
+  auto& actuator = robot.GetActuators().at(0).get();
+  EXPECT_EQ(actuator.GetSignalCount(), 3);
+  EXPECT_EQ(actuator.GetSignalIndex(0), 7);
+  EXPECT_EQ(actuator.GetSignalIndex(1), 8);
+  EXPECT_EQ(actuator.GetSignalIndex(2), 9);
+  EXPECT_EQ(controller_ptr->index_lookup_count, 3);
 }
 
 TEST(Actuator, LoadsTwoActuatorsSameID) {

--- a/core_sim/test/gtest_tilt.cpp
+++ b/core_sim/test/gtest_tilt.cpp
@@ -102,8 +102,9 @@ TEST(Tilt, UpdateActuatorOutputUpdatesRotationAndTransform) {
   auto* tilt = dynamic_cast<projectairsim::Tilt*>(actuator.get());
   ASSERT_NE(tilt, nullptr);
 
-  // Act: run `tilt->UpdateActuatorOutput(std::vector<float>{0.25f}, 200'000'000LL);`.
-  tilt->UpdateActuatorOutput(std::vector<float>{0.25f}, 200'000'000LL);
+  // Act: update the tilt with a scalar control signal.
+  projectairsim::Actuator::ControlSignals control_signals = {0.25f};
+  tilt->UpdateActuatorOutput(control_signals, 200'000'000LL);
 
   // Assert: check result from `const auto& control_rotation = tilt->GetControlRotation();`.
   const auto& control_rotation = tilt->GetControlRotation();

--- a/vehicle_apis/multirotor_api/include/arducopter_api.hpp
+++ b/vehicle_apis/multirotor_api/include/arducopter_api.hpp
@@ -44,6 +44,9 @@ class ArduCopterApi : public VTOLFWApiBase {
   void Reset() override;
   void SetKinematics(const Kinematics* kinematics) override;
   void Update() override;
+  int GetControlSignalIndex(const std::string& actuator_id) override;
+  void GetControlSignalSnapshot(std::vector<float>& control_signals) override;
+  std::vector<float> GetControlSignals(int signal_index) override;
   std::vector<float> GetControlSignals(const std::string& actuator_id) override;
   //---------------------------------------------------------------------------
   // IMultirotorApi overrides

--- a/vehicle_apis/multirotor_api/include/manual_controller_api.hpp
+++ b/vehicle_apis/multirotor_api/include/manual_controller_api.hpp
@@ -33,6 +33,9 @@ class ManualControllerApi : public IController {
   void Reset() override;
   void SetKinematics(const Kinematics* kinematics) override;
   void Update() override;
+  int GetControlSignalIndex(const std::string& actuator_id) override;
+  void GetControlSignalSnapshot(std::vector<float>& control_signals) override;
+  std::vector<float> GetControlSignals(int signal_index) override;
   std::vector<float> GetControlSignals(const std::string& actuator_id) override;
   const IController::GimbalState& GetGimbalSignal(
       const std::string& gimbal_id) override;

--- a/vehicle_apis/multirotor_api/include/matlab_controller_api.hpp
+++ b/vehicle_apis/multirotor_api/include/matlab_controller_api.hpp
@@ -40,6 +40,9 @@ class MatlabControllerApi : public IController {
   void Reset() override;
   void SetKinematics(const Kinematics* kinematics) override;
   void Update() override;
+  int GetControlSignalIndex(const std::string& actuator_id) override;
+  void GetControlSignalSnapshot(std::vector<float>& control_signals) override;
+  std::vector<float> GetControlSignals(int signal_index) override;
   std::vector<float> GetControlSignals(const std::string& actuator_id) override;
   const IController::GimbalState& GetGimbalSignal(
       const std::string& gimbal_id) override;

--- a/vehicle_apis/multirotor_api/include/mavlink_api.hpp
+++ b/vehicle_apis/multirotor_api/include/mavlink_api.hpp
@@ -50,6 +50,9 @@ class MavLinkApi : public VTOLFWApiBase {
   void Reset() override;
   void SetKinematics(const Kinematics* kinematics) override;
   void Update() override;
+  int GetControlSignalIndex(const std::string& actuator_id) override;
+  void GetControlSignalSnapshot(std::vector<float>& control_signals) override;
+  std::vector<float> GetControlSignals(int signal_index) override;
   std::vector<float> GetControlSignals(const std::string& actuator_id) override;
   const IController::GimbalState& GetGimbalSignal(
       const std::string& gimbal_id) override;

--- a/vehicle_apis/multirotor_api/include/multirotor_api_base.hpp
+++ b/vehicle_apis/multirotor_api/include/multirotor_api_base.hpp
@@ -42,6 +42,10 @@ class MultirotorApiBase : public IController,
   void Reset() override = 0;
   void SetKinematics(const Kinematics* kinematics) override = 0;
   void Update() override = 0;
+  int GetControlSignalIndex(const std::string& actuator_id) override = 0;
+  void GetControlSignalSnapshot(std::vector<float>& control_signals) override =
+      0;
+  std::vector<float> GetControlSignals(int signal_index) override = 0;
   std::vector<float> GetControlSignals(
       const std::string& actuator_id) override = 0;
   const IController::GimbalState& GetGimbalSignal(

--- a/vehicle_apis/multirotor_api/include/simple_flight_api.hpp
+++ b/vehicle_apis/multirotor_api/include/simple_flight_api.hpp
@@ -44,6 +44,9 @@ class SimpleFlightApi : public VTOLFWApiBase {
   void Reset() override;
   void SetKinematics(const Kinematics* kinematics) override;
   void Update() override;
+  int GetControlSignalIndex(const std::string& actuator_id) override;
+  void GetControlSignalSnapshot(std::vector<float>& control_signals) override;
+  std::vector<float> GetControlSignals(int signal_index) override;
   std::vector<float> GetControlSignals(const std::string& actuator_id) override;
 
   //---------------------------------------------------------------------------

--- a/vehicle_apis/multirotor_api/src/arducopter_api.cpp
+++ b/vehicle_apis/multirotor_api/src/arducopter_api.cpp
@@ -221,23 +221,45 @@ void ArduCopterApi::ReciveRotorsControls() {
   // HandleLockStep();
 }
 
-std::vector<float> ArduCopterApi::GetControlSignals(const std::string& actuator_id) {
-  if (!is_simulation_mode_) {
-    throw std::logic_error(
-        "Attempt to read motor controls while not in simulation mode");
-  }
-
+int ArduCopterApi::GetControlSignalIndex(const std::string& actuator_id) {
   auto actuator_map_itr = actuator_id_to_output_idx_map_.find(actuator_id);
   if (actuator_map_itr == actuator_id_to_output_idx_map_.end()) {
     GetLogger().LogWarning(
         GetControllerName(),
         "ArduCopterApi::GetControlSignal() called for invalid actuator: %s",
         actuator_id.c_str());
-    return std::vector<float>(1,0.f);
+    return -1;
+  }
+
+  return actuator_map_itr->second;
+}
+
+void ArduCopterApi::GetControlSignalSnapshot(
+    std::vector<float>& control_signals) {
+  if (!is_simulation_mode_) {
+    throw std::logic_error(
+        "Attempt to read motor controls while not in simulation mode");
+  }
+  control_signals.assign(control_outputs_,
+                         control_outputs_ + k_control_outputs_count_);
+}
+
+std::vector<float> ArduCopterApi::GetControlSignals(int signal_index) {
+  if (!is_simulation_mode_) {
+    throw std::logic_error(
+        "Attempt to read motor controls while not in simulation mode");
+  }
+  if (signal_index < 0 || signal_index >= k_control_outputs_count_) {
+    return std::vector<float>(1, 0.f);
   }
 
   // std::lock_guard<std::mutex> guard(hil_controls_mutex_);
-  return std::vector<float>(1, control_outputs_[actuator_map_itr->second]);
+  return std::vector<float>(1, control_outputs_[signal_index]);
+}
+
+std::vector<float> ArduCopterApi::GetControlSignals(
+    const std::string& actuator_id) {
+  return GetControlSignals(GetControlSignalIndex(actuator_id));
 }
 
 //---------------------------------------------------------------------------

--- a/vehicle_apis/multirotor_api/src/manual_controller_api.cpp
+++ b/vehicle_apis/multirotor_api/src/manual_controller_api.cpp
@@ -33,21 +33,38 @@ void ManualControllerApi::SetKinematics(const Kinematics* kinematics) {}
 
 void ManualControllerApi::Update() {}
 
-std::vector<float> ManualControllerApi::GetControlSignals(const std::string& actuator_id) {
-  std::lock_guard<std::mutex> lock(update_lock_);
-
+int ManualControllerApi::GetControlSignalIndex(const std::string& actuator_id) {
   auto actuator_map_itr = actuator_id_to_output_idx_map_.find(actuator_id);
   if (actuator_map_itr == actuator_id_to_output_idx_map_.end()) {
     GetLogger().LogWarning("ManualControllerApi",
                            "ManualControllerApi::GetControlSignal() called for "
                            "invalid actuator: %s",
                            actuator_id.c_str());
-    return std::vector<float>(1,0.0f);
+    return -1;
   }
 
-  float output = motor_output_.at(actuator_map_itr->second);
+  return actuator_map_itr->second;
+}
 
-  return std::vector<float>(1, output);
+void ManualControllerApi::GetControlSignalSnapshot(
+    std::vector<float>& control_signals) {
+  std::lock_guard<std::mutex> lock(update_lock_);
+  control_signals.assign(motor_output_.begin(), motor_output_.end());
+}
+
+std::vector<float> ManualControllerApi::GetControlSignals(int signal_index) {
+  std::lock_guard<std::mutex> lock(update_lock_);
+  if (signal_index < 0 ||
+      signal_index >= static_cast<int>(motor_output_.size())) {
+    return std::vector<float>(1, 0.f);
+  }
+
+  return std::vector<float>(1, motor_output_[signal_index]);
+}
+
+std::vector<float> ManualControllerApi::GetControlSignals(
+    const std::string& actuator_id) {
+  return GetControlSignals(GetControlSignalIndex(actuator_id));
 }
 
 const IController::GimbalState& ManualControllerApi::GetGimbalSignal(

--- a/vehicle_apis/multirotor_api/src/matlab_controller_api.cpp
+++ b/vehicle_apis/multirotor_api/src/matlab_controller_api.cpp
@@ -208,18 +208,38 @@ void MatlabControllerApi::Update() {
   }
 }
 
-std::vector<float> MatlabControllerApi::GetControlSignals(const std::string& actuator_id) {
-  std::lock_guard<std::mutex> lock(update_lock_);
-
+int MatlabControllerApi::GetControlSignalIndex(const std::string& actuator_id) {
   auto actuator_map_itr = actuator_id_to_output_idx_map_.find(actuator_id);
   if (actuator_map_itr == actuator_id_to_output_idx_map_.end()) {
     GetLogger().LogWarning("MatlabControllerApi",
                            "MatlabControllerApi::GetControlSignal() called for "
                            "invalid actuator: %s",
                            actuator_id.c_str());
+    return -1;
+  }
+
+  return actuator_map_itr->second;
+}
+
+void MatlabControllerApi::GetControlSignalSnapshot(
+    std::vector<float>& control_signals) {
+  std::lock_guard<std::mutex> lock(update_lock_);
+  control_signals.assign(motor_output_.begin(), motor_output_.end());
+}
+
+std::vector<float> MatlabControllerApi::GetControlSignals(int signal_index) {
+  std::lock_guard<std::mutex> lock(update_lock_);
+  if (signal_index < 0 ||
+      signal_index >= static_cast<int>(motor_output_.size())) {
     return std::vector<float>(1, 0.f);
   }
-  return std::vector<float>(1, motor_output_.at(actuator_map_itr->second));
+
+  return std::vector<float>(1, motor_output_[signal_index]);
+}
+
+std::vector<float> MatlabControllerApi::GetControlSignals(
+    const std::string& actuator_id) {
+  return GetControlSignals(GetControlSignalIndex(actuator_id));
 }
 
 const IController::GimbalState& MatlabControllerApi::GetGimbalSignal(

--- a/vehicle_apis/multirotor_api/src/mavlink_api.cpp
+++ b/vehicle_apis/multirotor_api/src/mavlink_api.cpp
@@ -373,23 +373,45 @@ void MavLinkApi::InitializeGimbalStatus(const Robot& robot) {
   }
 }
 
-std::vector<float> MavLinkApi::GetControlSignals(const std::string& actuator_id) {
-  if (!is_simulation_mode_) {
-    throw std::logic_error(
-        "Attempt to read motor controls while not in simulation mode");
-  }
-
+int MavLinkApi::GetControlSignalIndex(const std::string& actuator_id) {
   auto actuator_map_itr = actuator_id_to_output_idx_map_.find(actuator_id);
   if (actuator_map_itr == actuator_id_to_output_idx_map_.end()) {
     GetLogger().LogWarning(
         GetControllerName(),
         "MavLinkApi::GetControlSignal() called for invalid actuator: %s",
         actuator_id.c_str());
+    return -1;
+  }
+
+  return actuator_map_itr->second;
+}
+
+void MavLinkApi::GetControlSignalSnapshot(std::vector<float>& control_signals) {
+  if (!is_simulation_mode_) {
+    throw std::logic_error(
+        "Attempt to read motor controls while not in simulation mode");
+  }
+  std::lock_guard<std::mutex> guard(hil_controls_mutex_);
+  control_signals.assign(control_outputs_,
+                         control_outputs_ + kControlOutputsCount);
+}
+
+std::vector<float> MavLinkApi::GetControlSignals(int signal_index) {
+  if (!is_simulation_mode_) {
+    throw std::logic_error(
+        "Attempt to read motor controls while not in simulation mode");
+  }
+  if (signal_index < 0 || signal_index >= kControlOutputsCount) {
     return std::vector<float>(1, 0.f);
   }
 
   std::lock_guard<std::mutex> guard(hil_controls_mutex_);
-  return std::vector<float>(1, control_outputs_[actuator_map_itr->second]);
+  return std::vector<float>(1, control_outputs_[signal_index]);
+}
+
+std::vector<float> MavLinkApi::GetControlSignals(
+    const std::string& actuator_id) {
+  return GetControlSignals(GetControlSignalIndex(actuator_id));
 }
 
 const IController::GimbalState& MavLinkApi::GetGimbalSignal(

--- a/vehicle_apis/multirotor_api/src/simple_flight_api.cpp
+++ b/vehicle_apis/multirotor_api/src/simple_flight_api.cpp
@@ -152,17 +152,37 @@ void SimpleFlightApi::Update() {
   firmware_->Update();
 };
 
-std::vector<float> SimpleFlightApi::GetControlSignals(const std::string& actuator_id) {
+int SimpleFlightApi::GetControlSignalIndex(const std::string& actuator_id) {
   auto actuator_map_itr = actuator_id_to_output_idx_map_.find(actuator_id);
   if (actuator_map_itr == actuator_id_to_output_idx_map_.end()) {
     GetLogger().LogWarning(
         GetControllerName(),
         "SimpleFlightApi::GetControlSignal() called for invalid actuator: %s",
         actuator_id.c_str());
-    return std::vector<float>(1,0.f);
+    return -1;
   }
 
-  return std::vector<float>(1, board_->GetMotorControlSignal(actuator_map_itr->second));
+  return actuator_map_itr->second;
+}
+
+void SimpleFlightApi::GetControlSignalSnapshot(
+    std::vector<float>& control_signals) {
+  control_signals.resize(actuator_id_to_output_idx_map_.size());
+  for (size_t signal_index = 0; signal_index < control_signals.size();
+       ++signal_index) {
+    control_signals[signal_index] = board_->GetMotorControlSignal(signal_index);
+  }
+}
+
+std::vector<float> SimpleFlightApi::GetControlSignals(int signal_index) {
+  if (signal_index < 0) return std::vector<float>(1, 0.f);
+
+  return std::vector<float>(1, board_->GetMotorControlSignal(signal_index));
+}
+
+std::vector<float> SimpleFlightApi::GetControlSignals(
+    const std::string& actuator_id) {
+  return GetControlSignals(GetControlSignalIndex(actuator_id));
 }
 
 //---------------------------------------------------------------------------

--- a/vehicle_apis/rover_api/include/simple_drive/simple_drive_api.hpp
+++ b/vehicle_apis/rover_api/include/simple_drive/simple_drive_api.hpp
@@ -69,6 +69,11 @@ class SimpleDriveApi : public AckermannApiBase {
   void Reset(void) override;
   void SetKinematics(const Kinematics* kinematics) override;
   void Update(void) override;
+  int GetControlSignalIndex(const std::string& actuator_id) override;
+  int GetControlSignalIndex(const std::string& actuator_id,
+                            size_t signal_offset) override;
+  void GetControlSignalSnapshot(std::vector<float>& control_signals) override;
+  std::vector<float> GetControlSignals(int signal_index) override;
   std::vector<float> GetControlSignals(const std::string& actuator_id) override;
   const IController::GimbalState& GetGimbalSignal(
       const std::string& gimbal_id) override;

--- a/vehicle_apis/rover_api/src/simple_drive/simple_drive_api.cpp
+++ b/vehicle_apis/rover_api/src/simple_drive/simple_drive_api.cpp
@@ -5,6 +5,8 @@
 
 #include "simple_drive/simple_drive_api.hpp"
 
+#include <algorithm>
+
 #include "json.hpp"
 #include "simple_drive/ackermann_controller.hpp"
 #include "simple_drive/utils.hpp"
@@ -113,32 +115,50 @@ void SimpleDriveApi::Update(void) {
     pisimple_drive_controller_->Update();
 }
 
+int SimpleDriveApi::GetControlSignalIndex(const std::string& actuator_id) {
+  return GetControlSignalIndex(actuator_id, 0);
+}
+
+int SimpleDriveApi::GetControlSignalIndex(const std::string& actuator_id,
+                                          size_t signal_offset) {
+  // Simple-drive provides the same throttle/steering/brake channels to every
+  // wheel. The offset selects the scalar channel within that shared output.
+  return signal_offset < 3 ? static_cast<int>(signal_offset) : -1;
+}
+
+void SimpleDriveApi::GetControlSignalSnapshot(
+    std::vector<float>& control_signals) {
+  constexpr size_t kControlSignalCount = 3;
+  control_signals.assign(kControlSignalCount, 0.0f);
+  if ((vehicle_state_ != VehicleStateType::kArmed) ||
+      (pisimple_drive_controller_ == nullptr)) {
+    return;
+  }
+
+  const auto& controller_output = pisimple_drive_controller_->GetOutput();
+  const auto copy_count =
+      std::min(control_signals.size(), controller_output.size());
+  std::copy_n(controller_output.begin(), copy_count, control_signals.begin());
+}
+
+std::vector<float> SimpleDriveApi::GetControlSignals(int signal_index) {
+  if (signal_index < 0 || signal_index >= 3 ||
+      vehicle_state_ != VehicleStateType::kArmed ||
+      pisimple_drive_controller_ == nullptr) {
+    return std::vector<float>(1, 0.0f);
+  }
+
+  const auto& controller_output = pisimple_drive_controller_->GetOutput();
+  if (signal_index >= static_cast<int>(controller_output.size())) {
+    return std::vector<float>(1, 0.0f);
+  }
+
+  return std::vector<float>(1, controller_output[signal_index]);
+}
+
 std::vector<float> SimpleDriveApi::GetControlSignals(
     const std::string& actuator_id) {
-  // auto actuator_map_itr = actuator_id_to_output_idx_map_.find(actuator_id);
-
-  if ((vehicle_state_ != VehicleStateType::kArmed) ||
-      (pisimple_drive_controller_ == nullptr))
-    return std::vector<float>{0, 0, 0};
-  else {
-    static int kNumValueReturn =
-        3;  // Number of values to return: throttle, steering, and brake
-
-    std::vector<float> vecrRet;
-
-    auto& vecr = pisimple_drive_controller_->GetOutput();
-    auto cr = vecr.size();
-
-    if (cr == kNumValueReturn)
-      return (vecr);
-    else if (cr < kNumValueReturn) {
-      vecrRet = vecr;
-      vecrRet.resize(kNumValueReturn);
-    } else
-      vecrRet.assign(vecr.begin(), vecr.begin() + kNumValueReturn);
-
-    return vecrRet;
-  }
+  return GetControlSignals(GetControlSignalIndex(actuator_id));
 }
 
 const projectairsim::IController::GimbalState& SimpleDriveApi::GetGimbalSignal(


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

<!-- Fixes: # -->

## About

This PR optimizes how actuator control signals are retrieved during simulation updates.

Previously, every actuator requested its control signals by actuator ID on every update. This required repeated map lookups and, depending on the controller, repeated locks and temporary vector allocations.

This change:

- Resolves and caches control-signal indices when the controller is assigned to the robot.
- Retrieves a single, consistent snapshot of all control signals per simulation tick.
- Reuses the snapshot buffer between updates.
- Uses cached indices to access signals directly from the snapshot.
- Uses a fixed-size `std::array` when passing signals to actuators.
- Supports actuators that require multiple signals:
  - Wheels cache throttle, steering, and brake indices.
  - Other actuators cache one signal index.
- Makes `GetControlSignals(int signal_index)` return exactly one signal.
- Keeps the actuator-ID getter for backward compatibility.
- Updates all existing controller implementations to support snapshots.
- Adds tests for single-signal and multi-signal index caching.

This removes repeated map lookups, virtual calls, locks, and dynamic allocations from the actuator update loop. It also ensures that every actuator consumes signals from the same controller state during a simulation tick.

## How Has This Been Tested?

The following targets were successfully built and linked on Windows:

- `core_sim`
- `multirotor_api`
- `rover_api`
- `core_sim_gtests`
- `multirotor_api_gtests`
- `rover_api_gtests`

Test results:

- `core_sim`: 277 tests passed.
- `multirotor_api`: 1 test passed.
- `rover_api`: test executable passed; no tests are currently registered.
- Added coverage verifying that:
  - Single-signal actuators cache their controller signal index.
  - Wheel actuators cache all three signal indices.
  - Signal-index lookup only occurs when assigning the controller.
- `git diff --check` completed successfully.

## Screenshots and videos (if appropriate):

Not applicable. This PR only changes internal control-signal handling and does not introduce visual changes.
