### PR TITLE
Fix OpenSSL dependency build for UE 5.2 release packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -337,7 +337,11 @@ if(UNIX)
     # CMake external projects don't adopt the parent's CMAKE_MSVC_RUNTIME_LIBRARY setting,
     # so to force /MD non-debug CRT to match UE, build Debug config as Relwithdebinfo and
     # build Release as Release.
-    set(OPENSSL_BUILD_TYPE $<IF:$<CONFIG:Debug>,debug,release>)
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+        set(OPENSSL_BUILD_TYPE debug)
+    else()
+        set(OPENSSL_BUILD_TYPE release)
+    endif()
 
     # Build OpenSSL with the same compiler/sysroot as the rest of the project so that all
     # glibc symbol version requirements are consistent.  Use no-shared so only the static
@@ -382,8 +386,8 @@ if(UNIX)
         # Build/install only static runtime + dev artifacts; avoid build_sw/install_sw
         # which attempt to link provider DSOs (e.g., providers/legacy.so).
         BUILD_COMMAND           make build_libs
+        BUILD_BYPRODUCTS        ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_SSL_LIBRARY}
         INSTALL_COMMAND         make install_dev
-        INSTALL_BYPRODUCTS      ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_SSL_LIBRARY}
         TEST_COMMAND            ""  # disable test step
     )
     message("OPENSSL_LIB_DIR set to ${OPENSSL_LIB_DIR}")


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

<!-- Fixes: # -->

## About

This PR fixes the Linux release packaging build on `feature/release-tools-ue52`.

The GitHub Actions release workflow was failing while running:

```bash
bash source/tools/release/package_projectairsim_plugins.sh
```

with Ninja reporting that OpenSSL's static library was required but had no build rule:

```text
ninja: error: '_deps/openssl-install/lib64/libcrypto.a', needed by 'samples/standalone_sim/standalone_sim', missing and no known rule to make it
```

The fix keeps the release tools branch intact and only updates the OpenSSL external project wiring in `CMakeLists.txt`:

- resolves `OPENSSL_BUILD_TYPE` during configure instead of using a generator expression in the external project's configure command
- declares `libcrypto.a` and `libssl.a` as `BUILD_BYPRODUCTS` so Ninja knows they are produced by `openssl-external`

## How Has This Been Tested?

Tested locally on Linux with Unreal Engine 5.2:

```bash
rm -rf build/linux64/Release client/cpp/build_linux/Release

UE_ROOT=/home/unreal/UE_installed_build ./build.sh simlibs_release
```

This validates the failing portion of the release workflow: OpenSSL is built, `libcrypto.a`/`libssl.a` are produced, and the simlibs release build can progress past the previous Ninja dependency error.

The full `package_projectairsim_plugins.sh` command was also exercised locally until the Unreal shipping-build step, but this local UE installed build does not support Shipping targets. The original OpenSSL/Ninja failure was no longer reproduced.

## Screenshots and videos (if appropriate):

N/A