### PR TITLE
ardupilot docs

### DIFF
--- a/docs/config_robot.md
+++ b/docs/config_robot.md
@@ -320,10 +320,11 @@ A controller is used to decide how to command the robot's actuators in order to 
 | Parameter | Value | Description |
 | --------- | ----- | ----------- |
 | `id` | string | Name identifier for the controller. |
-| `airframe-setup` | string | Type of airframe. Simple Flight currently supports `quadrotor-x`, `hexarotor-x`, `vtol-quad-x-tailsitter`, and `vtol-quad-tiltrotor`, defaulting to `quadrotor-x` if omitted. PX4 ignores this setting because the airframe type is determined by the PX4 firmware that is running. |
-| `type` | string | Type of the controller. Currently, **[`simple-flight-api`](controllers/simple_flight.md)**, **[`px4-api`](controllers/px4/px4.md)**, and `manual-controller-api` are supported. |
+| `airframe-setup` | string | Type of airframe. Simple Flight currently supports `quadrotor-x`, `hexarotor-x`, `vtol-quad-x-tailsitter`, and `vtol-quad-tiltrotor`, defaulting to `quadrotor-x` if omitted. PX4 and ArduPilot obtain the airframe type from their running firmware. |
+| `type` | string | Type of the controller. Currently, **[`simple-flight-api`](controllers/simple_flight.md)**, **[`px4-api`](controllers/px4/px4.md)**, **[`ardupilot-api`](controllers/ardupilot.md)**, and `manual-controller-api` are supported. |
 | `simple-flight-api-settings` | See [Simple Flight settings](#simple-flight-settings) | Settings specific to the `simple-flight-api` controller type. |
 | `px4-settings` | See [PX4 settings](#px4-settings) | Settings specific to the `px4-api` controller type. |
+| `ardupilot-settings` | See [ArduPilot settings](#ardupilot-settings) | Settings specific to the `ardupilot-api` controller type. |
 | `manual-controller-api-settings` | See [Manual Controller settings](#manual-controller-settings) | Settings specific to the `manual-controller-api` controller type. |
 
 ### Simple Flight settings
@@ -341,6 +342,34 @@ The `simple-flight-api-settings` collection contains the settings for the Simple
 | Parameter | Value | Description |
 | --------- | ----- | ----------- |
 | `actuator-order` | Array of actuator `id` tags | The actuator name identifiers to link to the controller's commanded outputs.  See [Actuator order settings](#actuator-order-settings) below for the order. |
+
+### ArduPilot settings
+
+The `ardupilot-settings` collection contains the settings for the ArduPilot SITL controller:
+
+```json
+"ardupilot-settings": {
+  "local-host-ip": "127.0.0.1",
+  "ardupilot-ip": "127.0.0.1",
+  "ardupilot-udp-port": 9003,
+  "local-host-udp-port": 9002,
+  "use-distance-sensor": true,
+  "actuator-order": [
+    ...
+  ]
+}
+```
+
+| Parameter | Value | Description |
+| --------- | ----- | ----------- |
+| `local-host-ip` | string | IP address of the Project AirSim network adapter used for the ArduPilot UDP connection. Usually `127.0.0.1` when both run on the same computer. |
+| `ardupilot-ip` | string | IP address of the host running ArduPilot. Usually `127.0.0.1` when both run on the same computer. |
+| `ardupilot-udp-port` | integer | UDP port on the ArduPilot host. The supplied examples use `9003`. |
+| `local-host-udp-port` | integer | UDP port on the Project AirSim host. The supplied examples use `9002`. |
+| `use-distance-sensor` | bool | Sends distance-sensor data to ArduPilot when true. |
+| `actuator-order` | Array of actuator `id` tags | Ordered actuator identifiers linked to ArduPilot control outputs. See [Actuator order settings](#actuator-order-settings). |
+
+See [ArduPilot Flight Controller](controllers/ardupilot.md) for SITL setup, networking, and example flight sessions.
 
 ### PX4 settings
 
@@ -439,7 +468,7 @@ Project AirSim's GCS proxy also allows the GCS application can be run on a remot
 
 ### Actuator order settings
 
-Under `simple-flight-api-settings` and `px4-settings` this array maps the control outputs from the controller to the robot's actuators.
+Under `simple-flight-api-settings`, `px4-settings`, and `ardupilot-settings`, this array maps controller outputs to the robot's actuators.
 
 ``` json
 "simple-flight-api-settings": {

--- a/docs/controllers/ardupilot.md
+++ b/docs/controllers/ardupilot.md
@@ -1,0 +1,134 @@
+# ArduPilot Flight Controller
+
+[ArduPilot](https://ardupilot.org/) is a flexible open-source autopilot that can run with Project AirSim through Software-In-The-Loop (SITL). The repository includes quadrotor and hexarotor examples in [`client/python/example_user_scripts/ardupilot`](../../client/python/example_user_scripts/ardupilot).
+
+**Compatibility note:** this integration has not been recently validated against the latest ArduPilot release. Start with the supplied examples and their parameter files before adapting it to a different vehicle.
+
+## Supported airframes and control
+
+Project AirSim includes these ArduPilot SITL examples:
+
+| Airframe | Scene configuration | Client script | Parameter file |
+| --- | --- | --- | --- |
+| Quadrotor | `sim_config/scene_ardu_quadrotor.jsonc` | `ardupilot_quadrotor.py` | `project-airsim-quad.param` |
+| Hexarotor | `sim_config/scene_ardu_hexarotor.jsonc` | `ardupilot_hexarotor.py` | `project-airsim-hexa.param` |
+
+The examples display camera streams and load the scene; Project AirSim Client API flight commands such as arm, takeoff, and move are not supported with `ardupilot-api`. Control the vehicle from the ArduPilot console or through a ground control station (GCS), for example Mission Planner or QGroundControl.
+
+## ArduPilot settings
+
+Set the robot controller type to `ardupilot-api` and configure `ardupilot-settings`:
+
+```json
+"controller": {
+  "id": "ArduPilot_Controller",
+  "airframe-setup": "hexarotor-x",
+  "type": "ardupilot-api",
+  "ardupilot-settings": {
+    "local-host-ip": "127.0.0.1",
+    "ardupilot-ip": "127.0.0.1",
+    "ardupilot-udp-port": 9003,
+    "local-host-udp-port": 9002,
+    "use-distance-sensor": true,
+    "actuator-order": [
+      { "id": "Prop_2_actuator" }
+    ]
+  }
+}
+```
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `local-host-ip` | string | IP address of the Project AirSim host. |
+| `ardupilot-ip` | string | IP address of the ArduPilot host. |
+| `ardupilot-udp-port` | integer | UDP port on the ArduPilot host. The examples use `9003`. |
+| `local-host-udp-port` | integer | UDP port on the Project AirSim host. The examples use `9002`. |
+| `use-distance-sensor` | boolean | Sends distance-sensor data to ArduPilot when enabled. |
+| `actuator-order` | array | Ordered actuator identifiers connected to the ArduPilot outputs. |
+
+ArduPilot and Project AirSim exchange simulator messages, including sensor and actuator data, over UDP/IP. The Project AirSim receive port is `local-host-udp-port`.
+
+### Network configurations
+
+| Configuration | `ardupilot-ip` | `local-host-ip` |
+| --- | --- | --- |
+| Same Linux computer | `127.0.0.1` | `127.0.0.1` |
+| Separate computers | ArduPilot host IP | Project AirSim host IP |
+| ArduPilot in WSL1 | `127.0.0.1` | `127.0.0.1` |
+| ArduPilot in WSL2 | WSL virtual adapter IP | WSL virtual adapter IP |
+
+For WSL2, run `ipconfig` on Windows and use the IPv4 address of the WSL virtual network adapter in both settings. When using separate hosts or WSL, configure firewalls to allow the required UDP traffic. A GCS on another host also needs outgoing access from the Project AirSim host and incoming access on its configured UDP port.
+
+## Install and run ArduPilot SITL
+
+Complete the Project AirSim installation and [client setup](../client_setup.md), then prepare ArduPilot on a Linux host, VM, WSL1, or WSL2. The standard ArduPilot prerequisites may change, so consult the [ArduPilot build documentation](https://ardupilot.org/dev/docs/building-setup-linux.html) if the setup script reports an error.
+
+```bash
+git clone --recursive https://github.com/ArduPilot/ardupilot.git
+cd ardupilot
+Tools/environment_install/install-prereqs-ubuntu.sh -y
+```
+
+Copy the matching parameter file from the Project AirSim examples directory into ArduPilot's `Tools/autotest` directory. For a hexarotor, copy `project-airsim-hexa.param`; for a quadrotor, copy `project-airsim-quad.param`.
+
+Start the hexarotor SITL instance from the ArduPilot repository:
+
+```bash
+cd Tools/autotest
+python sim_vehicle.py -v ArduCopter -f airsim-copter --add-param-file=project-airsim-hexa.param
+```
+
+When ArduPilot runs in WSL2 or on a different computer, append `--sim-address=<project-airsim-host-ip>` to that command.
+
+### WSL1 display setup
+
+If you use an X Windows application in WSL1, install and start an X server such as VcXsrv. In XLaunch, select **Multiple windows**, then **Start no client**, and enable **Clipboard** without Native OpenGL. Set `DISPLAY` in WSL; the following persistent configuration uses the Windows-side nameserver address:
+
+```bash
+export DISPLAY=$(cat /etc/resolv.conf | grep nameserver | awk '{print $2}'):0
+```
+
+If the X client cannot connect, enable **Disable access control** in the X server only when appropriate for your environment.
+
+## Run an example flight session
+
+1. Start ArduPilot SITL with the matching parameter file.
+2. In a terminal with the Project AirSim Python client environment activated, change to `client/python/example_user_scripts/ardupilot`.
+3. Run `python ardupilot_hexarotor.py` or `python ardupilot_quadrotor.py`.
+4. Control the vehicle from the ArduPilot console or a GCS.
+
+For a local Linux host or WSL1, the checked-in configurations already use loopback addresses. For WSL2 or separate machines, update `local-host-ip` and `ardupilot-ip` in the matching `sim_config/robot_ardu_*.jsonc` file before running the example.
+
+Always stop Project AirSim before stopping ArduPilot. After Project AirSim stops, restart ArduPilot before beginning another session.
+
+### Useful ArduPilot console commands
+
+| Command | Notes |
+| --- | --- |
+| `arm throttle` | Arms the vehicle. |
+| `mode guided` | Wait until the console reports that EKF3 is using GPS before switching to Guided mode. |
+| `takeoff <alt>` | Takes off to the requested altitude in metres. Wait for completion before the next command. |
+| `guided <lat> <lon> <alt>` | Flies to latitude/longitude in degrees and altitude in metres. Wait for the waypoint to be reached. |
+| `mode land` | Lands the vehicle. |
+
+If `AP: Arm: Main loop slow...` appears, try `arm throttle` again. If it persists, review the simulation clock settings such as `step-ns`.
+
+## Autotune a different vehicle
+
+Vehicles other than the supplied examples should be autotuned for stable flight. Autotune can take hours.
+
+1. Run `arm throttle`.
+2. Run `rc3 1800` and wait until the vehicle is clear of obstacles.
+3. Run `rc3 1500`.
+4. Run `mode autotune`.
+
+ArduPilot reports the tuned roll, pitch, and yaw values in its console. Copy them to the corresponding `ATC_RAT_*`, `ATC_ANG_*`, and `ATC_ACCEL_*` entries in a `.param` file, then start SITL with `--add-param-file=<file>`. The supplied `project-airsim-hexa.param` and `project-airsim-quad.param` files are reference examples.
+
+It is safe to ignore an `AP: Auto-Tune: failing to level` message if it appears during the procedure.
+
+---
+
+Copyright (C) Microsoft Corporation.  
+Copyright (C) 2025 IAMAI CONSULTING CORP
+
+MIT License. All rights reserved.

--- a/docs/controllers/controllers.md
+++ b/docs/controllers/controllers.md
@@ -2,7 +2,7 @@
 
 A flight controller provides automatic control of the vehicle.  The amount of automatic control can vary from fully autonomous flight to assisted manual flight.
 
-Project AirSim supports the following flight controllers: Simple Flight, PX4 Autopilot, and Manual Controller.
+Project AirSim supports the following flight controllers: Simple Flight, PX4 Autopilot, ArduPilot, and Manual Controller.
 
 ## Simple Flight
 
@@ -14,6 +14,10 @@ Project AirSim supports the following flight controllers: Simple Flight, PX4 Aut
 
 If you are not familiar with setting up PX4, you may find it easier to start with Simple Flight if your airframe is supported.
 
+## ArduPilot
+
+[ArduPilot](ardupilot.md) is an open-source flight controller supported through a UDP/IP Software-In-The-Loop (SITL) connection. Project AirSim includes ready-to-run quadrotor and hexarotor examples. Its Client API flight commands are not supported; control the vehicle through ArduPilot or a ground control station such as Mission Planner or QGroundControl.
+
 ## Manual Controller
 
 Manual Controller is a pass-through controller type with control signal outputs that are set completely manually by API and optionally starts with initial values set by config. See [Manual Controller settings](../config_robot.md#manual-controller-settings) and [Manual Controller commands](../api.md#manual-controller-commands) for more details.
@@ -22,13 +26,13 @@ Manual Controller is a pass-through controller type with control signal outputs 
 
 The following chart compares the flight controllers when used with Project AirSim:
 
-Feature | Simple Flight | PX4 | Manual Controller
-------- | ------------- | --- | ---
-Project AirSim Airframes | Quadrotor, hexarotor, VTOL quad-x tailsitter, VTOL quad tiltrotor | Quadrotor, hexarotor, VTOL quad-x tailsitter, VTOL quad tiltrotor in SITL, quadrotor only in HITL | Any
-Controller Hardware | None | None for SITL, required for HITL | None
-Setup | Easy | Harder | Easy
-Use | Easy | Harder | Manual
-Tuning Support | No | Yes | N/A
+Feature | Simple Flight | PX4 | ArduPilot | Manual Controller
+------- | ------------- | --- | --------- | ---
+Project AirSim Airframes | Quadrotor, hexarotor, VTOL quad-x tailsitter, VTOL quad tiltrotor | Quadrotor, hexarotor, VTOL quad-x tailsitter, VTOL quad tiltrotor in SITL, quadrotor only in HITL | Quadrotor, hexarotor in SITL | Any
+Controller Hardware | None | None for SITL, required for HITL | None for SITL | None
+Setup | Easy | Harder | Harder | Easy
+Use | Easy | Harder | Harder | Manual
+Tuning Support | No | Yes | Yes | N/A
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,6 +64,7 @@ development/sensors/display.md
 
 controllers/controllers.md
 controllers/simple_flight.md
+controllers/ardupilot.md
 controllers/px4/px4.md
 controllers/px4/px4_build.md
 controllers/px4/px4_hitl.md


### PR DESCRIPTION
Fixes: #21

## About

Adds ArduPilot documentation to Project AirSim.

- Adds a dedicated ArduPilot SITL guide covering installation, configuration, networking, WSL1/WSL2, GCS usage, example sessions, console commands, and autotuning.
- Documents the existing quadrotor and hexarotor example scripts, scenes, and parameter files.
- Adds `ardupilot-api` and `ardupilot-settings` to the robot configuration reference.
- Adds ArduPilot to the controllers overview, comparison table, and documentation index.
- Notes that compatibility with the latest ArduPilot release has not been recently validated.

## How Has This Been Tested?

- Ran `git diff --check`.
- Verified the documented example paths and configuration setting names against the current repository files.

## Screenshots and videos (if appropriate):

N/A — documentation-only change.