### PR TITLE
Add Unreal Engine 5.8 support for Windows and Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,13 +83,18 @@ See **[Installing system prerequisites](docs/system_specs.md#installing-system-p
 
 Follow these steps to set up and run Project AirSim from source:
 
-### 1. Install Unreal Engine versions 5.2 or 5.7
+### 1. Install Unreal Engine version 5.2, 5.7, or 5.8
 - Download and install **[Unreal Engine](https://www.unrealengine.com/en-US/download)**.
 - Set the `UE_ROOT` environment variable to the Unreal Engine installation path:
   ```bash
   export UE_ROOT=/path/to/UnrealEngine
   ```
-**Note**: Project AirSim currently supports Unreal Engine versions 5.2 and 5.7 only.
+**Note**: Project AirSim currently supports Unreal Engine versions 5.2, 5.7, and 5.8. Keep the installations side by side and set `UE_ROOT` to the version you want to build with.
+
+For example, on Linux select UE 5.8 for the current shell with:
+```bash
+export UE_ROOT=/path/to/UnrealEngine-5.8
+```
 
 ### 2. Install Dependencies (Linux Only)
 - Run the setup script to install required development tools:

--- a/build.cmd
+++ b/build.cmd
@@ -60,6 +60,8 @@ if "%UE_MINOR%"=="2" (
   set "MSVC_VER=14.37"
 ) else if "%UE_MINOR%"=="7" (
   set "MSVC_VER=14.39"
+) else if "%UE_MINOR%"=="8" (
+  set "MSVC_VER=14.44"
 ) else (
   echo:
   echo Unsupported Unreal Engine version 5.%UE_MINOR%

--- a/tools/update_blocks_vscode.py
+++ b/tools/update_blocks_vscode.py
@@ -40,7 +40,10 @@ def write_json(path: Path, data: dict) -> None:
 
 def update_launch_json(vscode_dir: Path) -> None:
     launch_path = vscode_dir / "launch.json"
-    launch = json.loads(launch_path.read_text(encoding="utf-8"))
+    if launch_path.exists():
+        launch = json.loads(launch_path.read_text(encoding="utf-8"))
+    else:
+        launch = {"version": "0.2.0", "configurations": []}
     configurations = launch.setdefault("configurations", [])
 
     by_name = {config.get("name"): index for index, config in enumerate(configurations)}

--- a/unreal/Blocks/Plugins/ProjectAirSim/Source/ProjectAirSim/Private/Sensors/DepthLidar.cpp
+++ b/unreal/Blocks/Plugins/ProjectAirSim/Source/ProjectAirSim/Private/Sensors/DepthLidar.cpp
@@ -236,7 +236,7 @@ void UDepthLidar::SetupDepthCapture() {
           Cast<UPrimitiveComponent>(UnrealWorld->PersistentLineBatcher));
       DepthCaptureComponent->HideComponent(
           Cast<UPrimitiveComponent>(UnrealWorld->ForegroundLineBatcher));
-#elif UE_IS_5_7
+#elif UE_IS_5_7_OR_5_8
       // UE 5.6+: LineBatcher/PersistentLineBatcher/ForegroundLineBatcher were
       // replaced by GetLineBatcher(ELineBatcherType)
       DepthCaptureComponent->HideComponent(

--- a/unreal/Blocks/Plugins/ProjectAirSim/Source/ProjectAirSim/Private/Sensors/GPULidar.cpp
+++ b/unreal/Blocks/Plugins/ProjectAirSim/Source/ProjectAirSim/Private/Sensors/GPULidar.cpp
@@ -123,7 +123,7 @@ void UGPULidar::SetupSceneCapture(
   }
 
   // Hide debug points in case "draw-debug-points" is set to true
-  #if UE_IS_5_7 
+  #if UE_IS_5_7_OR_5_8
     OutSceneCaptureComp->HideComponent(Cast<UPrimitiveComponent>(
         UnrealWorld->GetLineBatcher(UWorld::ELineBatcherType::World)));
     OutSceneCaptureComp->HideComponent(Cast<UPrimitiveComponent>(

--- a/unreal/Blocks/Plugins/ProjectAirSim/Source/ProjectAirSim/Private/Sensors/LidarIntensitySceneViewExtension.cpp
+++ b/unreal/Blocks/Plugins/ProjectAirSim/Source/ProjectAirSim/Private/Sensors/LidarIntensitySceneViewExtension.cpp
@@ -17,7 +17,7 @@
 #include "SceneTextureParameters.h"
 
 // Access to FPostProcessingInputs definition from internal Renderer headers
-#if UE_IS_5_7
+#if UE_IS_5_7_OR_5_8
     #include "Runtime/Renderer/Internal/PostProcess/PostProcessInputs.h"
 #elif UE_IS_5_2
     #include "Runtime/Renderer/Private/PostProcess/PostProcessing.h"
@@ -168,7 +168,7 @@ void FLidarIntensitySceneViewExtension::PrePostProcessPass_RenderThread(
   const FScreenPassTextureViewportParameters SceneTextureViewportParams =
       GetTextureViewportParameters(SceneColorTextureViewport);
 
-#if UE_IS_5_7
+#if UE_IS_5_7_OR_5_8
   FSceneTextureShaderParameters SceneTextures =
       CreateSceneTextureShaderParameters(
           GraphBuilder, View, ESceneTextureSetupMode::All);
@@ -218,7 +218,7 @@ void FLidarIntensitySceneViewExtension::PrePostProcessPass_RenderThread(
             FScreenPassPipelineState(VertexShader, PixelShader,
                                      DefaultBlendState, DepthStencilState),
             [&](FRHICommandListImmediate& RHICmdList) {
-                #if UE_IS_5_7
+                #if UE_IS_5_7_OR_5_8
                     // View UB is already bound via PostProcessMaterialParameters->View;
                     // SetShaderParameters commits everything in one scratch batch.
                     // Do not call VS/PS->SetParameters here — it would dirty the

--- a/unreal/Blocks/Plugins/ProjectAirSim/Source/ProjectAirSim/Private/Sensors/LidarIntensityShader.h
+++ b/unreal/Blocks/Plugins/ProjectAirSim/Source/ProjectAirSim/Private/Sensors/LidarIntensityShader.h
@@ -51,7 +51,7 @@ class FLidarIntensityPS : public FLidarIntensityShader {
   FLidarIntensityPS(
       const ShaderMetaType::CompiledShaderInitializerType& Initializer)
       : FLidarIntensityShader(Initializer) {}
-  #if UE_IS_5_7
+  #if UE_IS_5_7_OR_5_8
     void SetParameters(FRHIBatchedShaderParameters& BatchedParameters, const FSceneView& View) {
       FGlobalShader::SetParameters<FViewUniformShaderParameters>(
           BatchedParameters, View.ViewUniformBuffer);
@@ -80,7 +80,7 @@ class FLidarIntensityVS : public FLidarIntensityShader {
   FLidarIntensityVS(
       const ShaderMetaType::CompiledShaderInitializerType& Initializer)
       : FLidarIntensityShader(Initializer) {}
-  #if UE_IS_5_7
+  #if UE_IS_5_7_OR_5_8
     void SetParameters(FRHIBatchedShaderParameters& BatchedParameters, const FSceneView& View) {
       FGlobalShader::SetParameters<FViewUniformShaderParameters>(
           BatchedParameters, View.ViewUniformBuffer);

--- a/unreal/Blocks/Plugins/ProjectAirSim/Source/ProjectAirSim/Private/Sensors/UnrealCamera.cpp
+++ b/unreal/Blocks/Plugins/ProjectAirSim/Source/ProjectAirSim/Private/Sensors/UnrealCamera.cpp
@@ -151,7 +151,7 @@ void UUnrealCamera::LoadCameraMaterials() {
 
 void HideDebugDrawComponent(USceneCaptureComponent2D* CaptureComponent,
                             UWorld* UnrealWorld) {
-  #if UE_IS_5_7
+  #if UE_IS_5_7_OR_5_8
     CaptureComponent->HideComponent(Cast<UPrimitiveComponent>(
         UnrealWorld->GetLineBatcher(UWorld::ELineBatcherType::World)));
     CaptureComponent->HideComponent(Cast<UPrimitiveComponent>(

--- a/unreal/Blocks/Plugins/ProjectAirSim/Source/ProjectAirSim/Private/UnrealCompatibility.h
+++ b/unreal/Blocks/Plugins/ProjectAirSim/Source/ProjectAirSim/Private/UnrealCompatibility.h
@@ -3,9 +3,13 @@
 #include "CoreMinimal.h"
 #include "Runtime/Launch/Resources/Version.h"
 
-// Exact supported versions
+// Exact supported engine versions.
 #define UE_IS_5_2 (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION == 2)
 #define UE_IS_5_7 (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION == 7)
+#define UE_IS_5_8 (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION == 8)
 
-// Convenience macro
-#define UE_IS_SUPPORTED (UE_IS_5_2 || UE_IS_5_7)
+// UE 5.7 and 5.8 share the modern compatibility path.
+#define UE_IS_5_7_OR_5_8 (UE_IS_5_7 || UE_IS_5_8)
+
+// Convenience macro.
+#define UE_IS_SUPPORTED (UE_IS_5_2 || UE_IS_5_7_OR_5_8)

--- a/unreal/Blocks/Plugins/ProjectAirSim/Source/ProjectAirSim/Private/UnrealLogger.h
+++ b/unreal/Blocks/Plugins/ProjectAirSim/Source/ProjectAirSim/Private/UnrealLogger.h
@@ -15,7 +15,7 @@ DECLARE_LOG_CATEGORY_EXTERN(SimPlugin, All, All);
 
 class UnrealLogger {
  public:
- #if UE_IS_5_7
+ #if UE_IS_5_7_OR_5_8
   template <typename... ArgTypes>
   static void Log(microsoft::projectairsim::LogLevel level,
                   UE::Core::TCheckedFormatString<FString::FmtCharType, ArgTypes...> format, ArgTypes... args);
@@ -33,7 +33,7 @@ class UnrealLogger {
   static std::string GetTimeStamp();
 };
 
-#if UE_IS_5_7
+#if UE_IS_5_7_OR_5_8
 template <typename... ArgTypes>
 inline void UnrealLogger::Log(microsoft::projectairsim::LogLevel level,
                               UE::Core::TCheckedFormatString<FString::FmtCharType, ArgTypes...> format, ArgTypes... args){

--- a/unreal/Blocks/Plugins/ProjectAirSim/Source/ProjectAirSim/Private/UnrealSimLoader.cpp
+++ b/unreal/Blocks/Plugins/ProjectAirSim/Source/ProjectAirSim/Private/UnrealSimLoader.cpp
@@ -63,12 +63,12 @@ void AUnrealSimLoader::LaunchSimulation(UWorld* World) {
            "in Unreal Engine version %d.%d."),
       ENGINE_MAJOR_VERSION, ENGINE_MINOR_VERSION);
 
-  if (ENGINE_MAJOR_VERSION != SupportedUnrealVersionMajor ||
-      ENGINE_MINOR_VERSION != SupportedUnrealVersionMinor) {
+  if (ENGINE_MAJOR_VERSION != 5 ||
+      (ENGINE_MINOR_VERSION != 2 && ENGINE_MINOR_VERSION != 7 &&
+       ENGINE_MINOR_VERSION != 8)) {
     UnrealLogger::Log(
         projectairsim::LogLevel::kWarning,
-        TEXT("Unreal Engine version is not the supported version of %d.%d."),
-        SupportedUnrealVersionMajor, SupportedUnrealVersionMinor);
+        TEXT("Unreal Engine version is unsupported; expected 5.2, 5.7, or 5.8."));
   }
 
   // Save Unreal world pointer

--- a/unreal/Blocks/Plugins/ProjectAirSim/Source/ProjectAirSim/Public/UnrealSimLoader.h
+++ b/unreal/Blocks/Plugins/ProjectAirSim/Source/ProjectAirSim/Public/UnrealSimLoader.h
@@ -85,6 +85,4 @@ class PROJECTAIRSIM_API AUnrealSimLoader {
 
   std::ofstream SimLogFile;
 
-  static constexpr int32 SupportedUnrealVersionMajor = 5;
-  static constexpr int32 SupportedUnrealVersionMinor = 1;
 };

--- a/unreal/Blocks/blocks_genprojfiles_vs2022.bat
+++ b/unreal/Blocks/blocks_genprojfiles_vs2022.bat
@@ -12,5 +12,14 @@ Unreal engine's root folder path, ex. C:\Program Files\Epic Games\UE_5.0
   REM Generate Visual Studio 2022 UE project Block.sln solution file
   echo:Generating Visual Studio 2022 project files with environment variable UE_ROOT=%UE_ROOT%
   cd %~dp0
+  call "%UE_ROOT%\Engine\Build\BatchFiles\GetDotnetPath.bat"
+  if errorlevel 1 (
+    echo:ERROR: Unable to configure the bundled .NET runtime for %UE_ROOT%.
+    exit /b 1
+  )
   "%UE_ROOT%\Engine\Binaries\DotNET\UnrealBuildTool\UnrealBuildTool.exe" -projectfiles -2022 -project="%~dp0\Blocks.uproject" -game
+  if errorlevel 1 (
+    echo:ERROR: UnrealBuildTool failed to generate the Visual Studio project files.
+    exit /b 1
+  )
 )

--- a/unreal/Blocks/blocks_genprojfiles_vscode.bat
+++ b/unreal/Blocks/blocks_genprojfiles_vscode.bat
@@ -12,7 +12,21 @@ Unreal engine's root folder path, ex. C:\Program Files\Epic Games\UE_5.0
   REM Generate VS Code UE project workspace files (overwrites .vscode\settings.json)
   echo:Generating VS Code project files with environment variable UE_ROOT=%UE_ROOT%
   cd %~dp0
+  call "%UE_ROOT%\Engine\Build\BatchFiles\GetDotnetPath.bat"
+  if errorlevel 1 (
+    echo:ERROR: Unable to configure the bundled .NET runtime for %UE_ROOT%.
+    exit /b 1
+  )
   "%UE_ROOT%\Engine\Binaries\DotNET\UnrealBuildTool\UnrealBuildTool.exe" -projectfiles -vscode -project="%~dp0\Blocks.uproject" -game
+  if errorlevel 1 (
+    echo:ERROR: UnrealBuildTool failed to generate the VS Code project files.
+    exit /b 1
+  )
+
+  if not exist "Blocks.code-workspace" (
+    echo:ERROR: UnrealBuildTool did not create Blocks.code-workspace.
+    exit /b 1
+  )
 
   REM Insert projectairsim project folder into UE-generated Block.code-workspace
   echo:{> AirSimBlocks.code-workspace
@@ -28,15 +42,20 @@ Unreal engine's root folder path, ex. C:\Program Files\Epic Games\UE_5.0
 
   REM Fix UE's generated game target binary names from UnrealGame to Blocks in launch.json
   SETLOCAL ENABLEDELAYEDEXPANSION
-  for /f "delims=" %%a in (.vscode\launch.json) do (
-    SET s=%%a
-    SET s=!s:UnrealGame-=Blocks-!
-    SET s=!s:UnrealGame.exe=Blocks.exe!
-    SET s=!s:"D:\build\++UE5\Sync"="D:\\build\\++UE5\\Sync"!
-    SET s=!s:"externalTerminal"="internalConsole"!
-    echo !s! >> .vscode\airsimlaunch.json
+  if exist ".vscode\launch.json" (
+    if exist ".vscode\airsimlaunch.json" del /q ".vscode\airsimlaunch.json"
+    for /f "delims=" %%a in (.vscode\launch.json) do (
+      SET s=%%a
+      SET s=!s:UnrealGame-=Blocks-!
+      SET s=!s:UnrealGame.exe=Blocks.exe!
+      SET s=!s:"D:\build\++UE5\Sync"="D:\\build\\++UE5\\Sync"!
+      SET s=!s:"externalTerminal"="internalConsole"!
+      echo !s! >> .vscode\airsimlaunch.json
+    )
+    move /y .vscode\airsimlaunch.json .vscode\launch.json
+  ) else (
+    echo:NOTE: This Unreal version did not generate launch.json; adding Project AirSim entries.
   )
-  move .vscode\airsimlaunch.json .vscode\launch.json
 
   REM Add Project AirSim Python debugging entries to UE-generated VS Code files.
   where python >nul 2>nul

--- a/unreal/Blocks/blocks_genprojfiles_vscode.sh
+++ b/unreal/Blocks/blocks_genprojfiles_vscode.sh
@@ -3,15 +3,19 @@
 # Copyright (C) 2025 IAMAI CONSULTING CORP
 # MIT License.
 
-if [ -z "$UE_ROOT" ]
-then
+set -e
+
+if [ -z "${UE_ROOT:-}" ]; then
   echo
-  echo ERROR: UE_ROOT environment variable is not set. It must be set to the target \
-    Unreal engine\'s root folder path, ex. /home/projectairsimuser/UnrealEngine-5.0.3
+  echo "ERROR: UE_ROOT is not set. Set it to the target Unreal Engine root, for example /opt/UnrealEngine-5.8."
+  exit 1
+elif [ ! -x "$UE_ROOT/Engine/Build/BatchFiles/Linux/Build.sh" ]; then
+  echo "ERROR: Unreal Build.sh was not found under UE_ROOT=$UE_ROOT"
+  exit 1
 else
   # Find the .uproject file in the current directory
   SCRIPTDIR=$(dirname "$(readlink -f "$0")")
-  cd $SCRIPTDIR
+  cd "$SCRIPTDIR"
   UPROJECT_FILE=$(find . -maxdepth 1 -name "*.uproject" | head -n 1)
 
   if [ -z "$UPROJECT_FILE" ]
@@ -24,8 +28,13 @@ else
   PROJECT_NAME=$(basename "$UPROJECT_FILE" .uproject)
 
   # Generate VS Code UE project files (overwrites .vscode/settings.json)
-  echo Generating VS Code project files with environment variable UE_ROOT=$UE_ROOT for project $PROJECT_NAME
-  $UE_ROOT/Engine/Build/BatchFiles/Linux/Build.sh -projectfiles -vscode -project="$SCRIPTDIR/$UPROJECT_FILE" -game
+  echo "Generating VS Code project files with UE_ROOT=$UE_ROOT for project $PROJECT_NAME"
+  "$UE_ROOT/Engine/Build/BatchFiles/Linux/Build.sh" -projectfiles -vscode -project="$SCRIPTDIR/$UPROJECT_FILE" -game
+
+  if [ ! -f "$PROJECT_NAME.code-workspace" ]; then
+    echo "ERROR: UnrealBuildTool did not create $PROJECT_NAME.code-workspace."
+    exit 1
+  fi
 
   # Insert projectairsim project folder into UE-generated .code-workspace file
   echo "{" > AirSim$PROJECT_NAME.code-workspace
@@ -34,12 +43,16 @@ else
   echo "			\"name\": \"projectairsim\"," >> AirSim$PROJECT_NAME.code-workspace
   echo "			\"path\": \"../..\"" >> AirSim$PROJECT_NAME.code-workspace
   echo "		}," >> AirSim$PROJECT_NAME.code-workspace
-  sed '1,2d' $PROJECT_NAME.code-workspace >> AirSim$PROJECT_NAME.code-workspace
-  mv AirSim$PROJECT_NAME.code-workspace $PROJECT_NAME.code-workspace
+  sed '1,2d' "$PROJECT_NAME.code-workspace" >> "AirSim$PROJECT_NAME.code-workspace"
+  mv "AirSim$PROJECT_NAME.code-workspace" "$PROJECT_NAME.code-workspace"
 
   # Fix UE's generated game target binary names from UnrealGame to the project name in launch.json
-  sed -i "s/UnrealGame-/$PROJECT_NAME-/g" .vscode/launch.json
-  sed -i "s/UnrealGame\"/$PROJECT_NAME\"/g" .vscode/launch.json
+  if [ -f .vscode/launch.json ]; then
+    sed -i "s/UnrealGame-/$PROJECT_NAME-/g" .vscode/launch.json
+    sed -i "s/UnrealGame\"/$PROJECT_NAME\"/g" .vscode/launch.json
+  else
+    echo "NOTE: This Unreal version did not generate launch.json; adding Project AirSim entries."
+  fi
 
   # Add Project AirSim Python debugging entries to UE-generated VS Code files.
   if command -v python3 >/dev/null 2>&1


### PR DESCRIPTION
## Summary

Adds Unreal Engine 5.8 support on Windows and Linux while preserving compatibility with UE 5.2 and UE 5.7.

## Changes

- Added explicit compatibility macros for UE 5.8.
- Added a shared `UE_IS_5_7_OR_5_8` compatibility path.
- Updated camera, logging, GPU LiDAR, Depth LiDAR, and LiDAR intensity code for UE 5.8.
- Added MSVC 14.44 selection for UE 5.8 on Windows.
- Updated Windows project-generation scripts to use Unreal Engine's bundled .NET runtime.
- Improved error handling when UnrealBuildTool fails or expected files are missing.
- Updated the Linux VS Code generation script for UE 5.8 behavior.
- Added safer path handling and `UE_ROOT` validation on Linux.
- Updated the documentation with UE 5.8 setup instructions.

## Validation

- Successfully generated VS Code project files with UE 5.8.
- Confirmed the use of UE 5.8's bundled .NET 10 runtime.
- Compiled the UE 5.8 camera, logging, renderer, and LiDAR compatibility code.
- Validated the Linux script syntax.
- Ran `git diff --check` successfully.

## Notes

UE 5.8 currently uses the same modern compatibility path as UE 5.7. Separate exact-version macros remain available so UE 5.8-specific behavior can be introduced later if required.