### PR TITLE
Add standalone C++ client build scripts

### DIFF
--- a/.github/workflows/test_cpp_client.yml
+++ b/.github/workflows/test_cpp_client.yml
@@ -7,6 +7,8 @@ name: C++ Client and ROS 2 C++ Node CI
       - main
     paths:
       - ".github/workflows/test_cpp_client.yml"
+      - "build_cpp_client.cmd"
+      - "build_cpp_client.sh"
       - "client/cpp/**"
       - "client/python/example_user_scripts/sim_config/**"
       - "core_sim/**"
@@ -16,6 +18,8 @@ name: C++ Client and ROS 2 C++ Node CI
       - main
     paths:
       - ".github/workflows/test_cpp_client.yml"
+      - "build_cpp_client.cmd"
+      - "build_cpp_client.sh"
       - "client/cpp/**"
       - "client/python/example_user_scripts/sim_config/**"
       - "core_sim/**"
@@ -44,11 +48,15 @@ jobs:
           filters: |
             client:
               - '.github/workflows/test_cpp_client.yml'
+              - 'build_cpp_client.cmd'
+              - 'build_cpp_client.sh'
               - 'client/cpp/**'
               - 'client/python/example_user_scripts/sim_config/**'
               - 'core_sim/**'
             ros2:
               - '.github/workflows/test_cpp_client.yml'
+              - 'build_cpp_client.cmd'
+              - 'build_cpp_client.sh'
               - 'ros/projectairsim_ros2_cpp/**'
               - 'client/cpp/**'
               - 'client/python/example_user_scripts/sim_config/**'
@@ -67,17 +75,9 @@ jobs:
       - name: Enable Developer Command Prompt
         uses: ilammy/msvc-dev-cmd@v1
 
-      - name: Configure
+      - name: Build and run mocked unit tests
         shell: cmd
-        run: >
-          cmake -S client/cpp
-          -B client/cpp/build_windows/Release
-          -G Ninja
-          -DCMAKE_BUILD_TYPE=Release
-
-      - name: Build
-        shell: cmd
-        run: cmake --build client/cpp/build_windows/Release --config Release --parallel
+        run: call .\build_cpp_client.cmd release --tests
 
       - name: Package
         shell: cmd
@@ -188,17 +188,9 @@ jobs:
           sudo apt-get -y install --no-install-recommends \
             build-essential cmake ninja-build
 
-      - name: Configure
+      - name: Build and run mocked unit tests
         shell: bash
-        run: |
-          cmake -S client/cpp \
-            -B client/cpp/build_linux/Release \
-            -G Ninja \
-            -DCMAKE_BUILD_TYPE=Release
-
-      - name: Build
-        shell: bash
-        run: cmake --build client/cpp/build_linux/Release --config Release --parallel
+        run: ./build_cpp_client.sh release --tests
 
       - name: Package
         shell: bash

--- a/build_cpp_client.cmd
+++ b/build_cpp_client.cmd
@@ -1,0 +1,102 @@
+@echo off
+REM Copyright (C) Microsoft Corporation.
+REM Copyright (C) 2025 IAMAI CONSULTING CORP
+REM MIT License.
+
+setlocal EnableExtensions EnableDelayedExpansion
+
+set "BUILD_TYPE=Debug"
+set "RUN_TESTS=OFF"
+
+:parse_args
+if "%~1"=="" goto args_done
+if /I "%~1"=="debug" (
+  set "BUILD_TYPE=Debug"
+  shift
+  goto parse_args
+)
+if /I "%~1"=="release" (
+  set "BUILD_TYPE=Release"
+  shift
+  goto parse_args
+)
+if /I "%~1"=="--tests" (
+  set "RUN_TESTS=ON"
+  shift
+  goto parse_args
+)
+if /I "%~1"=="--test" (
+  set "RUN_TESTS=ON"
+  shift
+  goto parse_args
+)
+if /I "%~1"=="--help" goto usage
+if /I "%~1"=="-h" goto usage
+echo Unknown argument: %~1
+goto usage_error
+
+:args_done
+set "ROOT_DIR=%~dp0"
+
+REM Reuse an already initialized MSVC environment, such as a Developer
+REM Command Prompt or the environment prepared by CI.
+where /q cl.exe
+if not errorlevel 1 goto compiler_ready
+
+set "VS_INSTALL_DIR="
+if defined VSINSTALLDIR set "VS_INSTALL_DIR=%VSINSTALLDIR%"
+
+if not defined VS_INSTALL_DIR call :check_vs_install "%ProgramFiles%\Microsoft Visual Studio\2022\Community"
+if not defined VS_INSTALL_DIR call :check_vs_install "%ProgramFiles%\Microsoft Visual Studio\2022\Professional"
+if not defined VS_INSTALL_DIR call :check_vs_install "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise"
+if not defined VS_INSTALL_DIR call :check_vs_install "%SystemDrive%\Progra~2\Microsoft Visual Studio\2022\BuildTools"
+
+if not defined VS_INSTALL_DIR if exist "%SystemDrive%\Progra~2\Microsoft Visual Studio\Installer\vswhere.exe" (
+  for /f "tokens=*" %%I in ('"%SystemDrive%\Progra~2\Microsoft Visual Studio\Installer\vswhere.exe" -version "[17.0,18.0)" -latest -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath') do set "VS_INSTALL_DIR=%%I"
+)
+
+if not defined VS_INSTALL_DIR (
+  echo [ERROR] MSVC was not found. Install Visual Studio 2022 Build Tools with
+  echo         the Desktop development with C++ workload.
+  exit /b 1
+)
+
+call "%VS_INSTALL_DIR%\VC\Auxiliary\Build\vcvarsall.bat" x64
+if errorlevel 1 exit /b 1
+
+:compiler_ready
+where /q ninja
+if errorlevel 1 (
+  echo [ERROR] Ninja was not found. Install Ninja or add it to PATH.
+  exit /b 1
+)
+
+set "BUILD_DIR=%ROOT_DIR%client\cpp\build_windows\%BUILD_TYPE%"
+cmake -S "%ROOT_DIR%client\cpp" -B "%BUILD_DIR%" -G Ninja -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DBUILD_TESTING=%RUN_TESTS%
+if errorlevel 1 exit /b 1
+cmake --build "%BUILD_DIR%" --parallel
+if errorlevel 1 exit /b 1
+
+if /I "%RUN_TESTS%"=="ON" (
+  ctest --test-dir "%BUILD_DIR%" --output-on-failure
+  if errorlevel 1 exit /b 1
+)
+
+exit /b 0
+
+:check_vs_install
+if exist "%~1\VC\Auxiliary\Build\vcvarsall.bat" set "VS_INSTALL_DIR=%~1"
+exit /b 0
+
+:usage
+echo Usage: build_cpp_client.cmd [debug^|release] [--tests]
+echo.
+echo Build the standalone ProjectAirSim C++ client without building SimLibs.
+echo   debug       Build Debug artifacts (default).
+echo   release     Build Release artifacts.
+echo   --tests     Build and run the mocked unit tests. A simulator is not required.
+exit /b 0
+
+:usage_error
+call :usage
+exit /b 2

--- a/build_cpp_client.sh
+++ b/build_cpp_client.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Copyright (C) Microsoft Corporation.
+# Copyright (C) 2025 IAMAI CONSULTING CORP
+# MIT License.
+
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: ./build_cpp_client.sh [debug|release] [--tests]
+
+Build the standalone ProjectAirSim C++ client without building SimLibs.
+  debug       Build Debug artifacts (default).
+  release     Build Release artifacts.
+  --tests     Build and run the mocked unit tests. A simulator is not required.
+EOF
+}
+
+build_type=Debug
+run_tests=false
+
+for arg in "$@"; do
+    case "$arg" in
+        debug) build_type=Debug ;;
+        release) build_type=Release ;;
+        --tests|--test) run_tests=true ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "Unknown argument: $arg" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+build_dir="$root_dir/client/cpp/build_linux/$build_type"
+
+cmake -S "$root_dir/client/cpp" -B "$build_dir" -G Ninja \
+    -DCMAKE_BUILD_TYPE="$build_type" \
+    -DBUILD_TESTING="$run_tests"
+cmake --build "$build_dir" --parallel
+
+if "$run_tests"; then
+    ctest --test-dir "$build_dir" --output-on-failure
+fi

--- a/build_linux.mk
+++ b/build_linux.mk
@@ -26,11 +26,8 @@ default:
 	@echo " all_no_test = Build + Package everything"
 	@echo " clean = Clean sim libs + Blocks build files"
 	@echo
-	@echo " simlibs_debug = Build sim libs + C++ client for Debug"
-	@echo " simlibs_release = Build sim libs + C++ client for Release"
-	@echo " cpp_client_debug = Build C++ client only for Debug"
-	@echo " cpp_client_release = Build C++ client only for Release"
-	@echo " package_cpp_client = Build Release C++ client and create versioned package"
+	@echo " simlibs_debug = Build sim libs for Debug"
+	@echo " simlibs_release = Build sim libs for Release"
 	@echo " test_simlibs_debug = Test sim libs for Debug"
 	@echo " test_simlibs_release = Test sim libs for Release"
 	@echo
@@ -65,14 +62,6 @@ CMAKE_CMD = cmake -G "Ninja"
 CMAKE_DBG_BUILD_CMD = cmake --build $(CMAKE_BUILD_DIR)/Debug
 CMAKE_REL_BUILD_CMD = cmake --build $(CMAKE_BUILD_DIR)/Release
 
-CPP_CLIENT_DIR = client/cpp
-CPP_CLIENT_DBG_BUILD_DIR = $(CPP_CLIENT_DIR)/build_linux/Debug
-CPP_CLIENT_REL_BUILD_DIR = $(CPP_CLIENT_DIR)/build_linux/Release
-CPP_CLIENT_CMAKE_CMD = cmake -G "Ninja"
-CPP_CLIENT_DBG_BUILD_CMD = cmake --build $(CPP_CLIENT_DBG_BUILD_DIR) -j$(shell nproc)
-CPP_CLIENT_REL_BUILD_CMD = cmake --build $(CPP_CLIENT_REL_BUILD_DIR) -j$(shell nproc)
-CPP_CLIENT_PACKAGE_CMD = cmake --build $(CPP_CLIENT_REL_BUILD_DIR) --target package
-
 .PHONY: config_simlibs_debug
 config_simlibs_debug:
 	@echo "======================================================================="
@@ -80,40 +69,8 @@ config_simlibs_debug:
 	mkdir -p $(CMAKE_BUILD_DIR)/Debug $(REDIRECT_OUTPUT)
 	cd $(CMAKE_BUILD_DIR)/Debug && $(CMAKE_CMD) -DCMAKE_BUILD_TYPE=Debug ../../..
 
-.PHONY: config_cpp_client_debug
-config_cpp_client_debug:
-	@echo "======================================================================="
-	@echo "Configuring the C++ client project for Linux64-Debug..."
-	mkdir -p $(CPP_CLIENT_DBG_BUILD_DIR) $(REDIRECT_OUTPUT)
-	cd $(CPP_CLIENT_DBG_BUILD_DIR) && $(CPP_CLIENT_CMAKE_CMD) -DCMAKE_BUILD_TYPE=Debug $(CURDIR)/$(CPP_CLIENT_DIR)
-
-.PHONY: cpp_client_debug
-cpp_client_debug: config_cpp_client_debug
-	@echo "======================================================================="
-	@echo "Building the C++ client project for Linux64-Debug..."
-	$(CPP_CLIENT_DBG_BUILD_CMD)
-
-.PHONY: config_cpp_client_release
-config_cpp_client_release:
-	@echo "======================================================================="
-	@echo "Configuring the C++ client project for Linux64-Release..."
-	mkdir -p $(CPP_CLIENT_REL_BUILD_DIR) $(REDIRECT_OUTPUT)
-	cd $(CPP_CLIENT_REL_BUILD_DIR) && $(CPP_CLIENT_CMAKE_CMD) -DCMAKE_BUILD_TYPE=Release $(CURDIR)/$(CPP_CLIENT_DIR)
-
-.PHONY: cpp_client_release
-cpp_client_release: config_cpp_client_release
-	@echo "======================================================================="
-	@echo "Building the C++ client project for Linux64-Release..."
-	$(CPP_CLIENT_REL_BUILD_CMD)
-
-.PHONY: package_cpp_client
-package_cpp_client: cpp_client_release
-	@echo "======================================================================="
-	@echo "Packaging the C++ client for Linux64-Release..."
-	$(CPP_CLIENT_PACKAGE_CMD)
-
 .PHONY: simlibs_debug
-simlibs_debug: config_simlibs_debug cpp_client_debug
+simlibs_debug: config_simlibs_debug
 	@echo "======================================================================="
 	@echo "Building the ProjectAirSimLibs project for Linux64-Debug..."
 	$(CMAKE_DBG_BUILD_CMD)
@@ -126,7 +83,7 @@ config_simlibs_release:
 	cd $(CMAKE_BUILD_DIR)/Release && $(CMAKE_CMD) -DCMAKE_BUILD_TYPE=Release ../../..
 
 .PHONY: simlibs_release
-simlibs_release: config_simlibs_release cpp_client_release
+simlibs_release: config_simlibs_release
 	@echo "======================================================================="
 	@echo "Building the ProjectAirSimLibs project for Linux64-Release..."
 	$(CMAKE_REL_BUILD_CMD)
@@ -145,7 +102,6 @@ clean:
 	@echo "======================================================================="
 	@echo "Cleaning build files..."
 	rm -fr $(CMAKE_BUILD_DIR) $(REDIRECT_OUTPUT)
-	rm -fr $(CPP_CLIENT_DIR)/build_linux $(REDIRECT_OUTPUT)
 	rm -fr physics/matlab_sfunc/_deps $(REDIRECT_OUTPUT)
 	rm -fr physics/matlab_sfunc/message $(REDIRECT_OUTPUT)
 	rm -fr packages/projectairsim_simlibs $(REDIRECT_OUTPUT)

--- a/build_windows.mk
+++ b/build_windows.mk
@@ -24,13 +24,10 @@ default:
 	@echo. all = Build + Test + Package everything
 	@echo. rebuild_all = Clean + Build + Test + Package everything
 	@echo. all_no_test = Build + Package everything
-	@echo. clean = Clean sim libs, C++ client, and Blocks build files
+	@echo. clean = Clean sim libs and Blocks build files
 	@echo.
-	@echo. simlibs_debug = Build + Package sim libs for Debug
-	@echo. simlibs_release = Build + Package sim libs for Release
-	@echo. cpp_client_debug = Build C++ client artifacts for Debug
-	@echo. cpp_client_release = Build C++ client artifacts for Release
-	@echo. package_cpp_client = Build Release C++ client and create versioned package
+	@echo. simlibs_debug = Build sim libs for Debug
+	@echo. simlibs_release = Build sim libs for Release
 	@echo. test_simlibs_debug = Test sim libs for Debug
 	@echo. test_simlibs_release = Test sim libs for Release
 	@echo.
@@ -66,49 +63,6 @@ CMAKE_CMD = cmake -G "Ninja" \
 CMAKE_DBG_BUILD_CMD = cmake --build $(CMAKE_BUILD_DIR)\Debug
 CMAKE_REL_BUILD_CMD = cmake --build $(CMAKE_BUILD_DIR)\Release
 
-CPP_CLIENT_DIR = client\cpp
-CPP_CLIENT_BUILD_DIR = $(CPP_CLIENT_DIR)\build_windows
-CPP_CLIENT_DBG_BUILD_DIR = $(CPP_CLIENT_BUILD_DIR)\Debug
-CPP_CLIENT_REL_BUILD_DIR = $(CPP_CLIENT_BUILD_DIR)\Release
-CPP_CLIENT_CMAKE_CMD = cmake -G "Ninja" \
-				  -DCMAKE_C_COMPILER=cl.exe \
-				  -DCMAKE_CXX_COMPILER=cl.exe
-CPP_CLIENT_DBG_BUILD_CMD = cmake --build $(CPP_CLIENT_DBG_BUILD_DIR)
-CPP_CLIENT_REL_BUILD_CMD = cmake --build $(CPP_CLIENT_REL_BUILD_DIR)
-CPP_CLIENT_PACKAGE_CMD = cmake --build $(CPP_CLIENT_REL_BUILD_DIR) --target package
-
-.PHONY: config_cpp_client_debug
-config_cpp_client_debug:
-	@echo =======================================================================
-	@echo Configuring the C++ client project for Win64-Debug...
-	-mkdir $(CPP_CLIENT_DBG_BUILD_DIR) $(REDIRECT_OUTPUT)
-	cd $(CPP_CLIENT_DBG_BUILD_DIR) && $(CPP_CLIENT_CMAKE_CMD) -DCMAKE_BUILD_TYPE=Debug "%CD%\$(CPP_CLIENT_DIR)"
-
-.PHONY: cpp_client_debug
-cpp_client_debug: config_cpp_client_debug
-	@echo =======================================================================
-	@echo Building the C++ client artifacts for Win64-Debug...
-	$(CPP_CLIENT_DBG_BUILD_CMD)
-
-.PHONY: config_cpp_client_release
-config_cpp_client_release:
-	@echo =======================================================================
-	@echo Configuring the C++ client project for Win64-Release...
-	-mkdir $(CPP_CLIENT_REL_BUILD_DIR) $(REDIRECT_OUTPUT)
-	cd $(CPP_CLIENT_REL_BUILD_DIR) && $(CPP_CLIENT_CMAKE_CMD) -DCMAKE_BUILD_TYPE=Release "%CD%\$(CPP_CLIENT_DIR)"
-
-.PHONY: cpp_client_release
-cpp_client_release: config_cpp_client_release
-	@echo =======================================================================
-	@echo Building the C++ client artifacts for Win64-Release...
-	$(CPP_CLIENT_REL_BUILD_CMD)
-
-.PHONY: package_cpp_client
-package_cpp_client: cpp_client_release
-	@echo =======================================================================
-	@echo Packaging the C++ client for Win64-Release...
-	$(CPP_CLIENT_PACKAGE_CMD)
-
 .PHONY: config_simlibs_debug
 config_simlibs_debug:
 	@echo =======================================================================
@@ -123,7 +77,7 @@ build_simlibs_debug: config_simlibs_debug
 	$(CMAKE_DBG_BUILD_CMD)
 
 .PHONY: simlibs_debug
-simlibs_debug: build_simlibs_debug cpp_client_debug
+simlibs_debug: build_simlibs_debug
 
 .PHONY: config_simlibs_release
 config_simlibs_release:
@@ -139,7 +93,7 @@ build_simlibs_release: config_simlibs_release
 	$(CMAKE_REL_BUILD_CMD)
 
 .PHONY: simlibs_release
-simlibs_release: build_simlibs_release cpp_client_release
+simlibs_release: build_simlibs_release
 
 .PHONY: package_simlibs
 package_simlibs: simlibs_debug simlibs_release
@@ -155,12 +109,8 @@ clean:
 	@echo =======================================================================
 	@echo Cleaning build files...
 	-rmdir /S /Q $(CMAKE_BUILD_DIR) $(REDIRECT_OUTPUT)
-	-rmdir /S /Q $(CPP_CLIENT_BUILD_DIR) $(REDIRECT_OUTPUT)
 	-rmdir /S /Q physics\matlab_sfunc\_deps $(REDIRECT_OUTPUT)
 	-rmdir /S /Q physics\matlab_sfunc\message $(REDIRECT_OUTPUT)
-	-rmdir /S /Q client\cpp\libraries $(REDIRECT_OUTPUT)
-	-rmdir /S /Q client\cpp\example_user_apps\HelloDrone\x64 $(REDIRECT_OUTPUT)
-	-rmdir /S /Q client\cpp\example_user_apps\HelloDrone\HelloDrone $(REDIRECT_OUTPUT)
 	-rmdir /S /Q packages\projectairsim_simlibs $(REDIRECT_OUTPUT)
 	-rmdir /S /Q packages\projectairsim_cpp_client $(REDIRECT_OUTPUT)
 	-rmdir /S /Q unreal\Blocks\Plugins\ProjectAirSim\SimLibs $(REDIRECT_OUTPUT)

--- a/client/cpp/CMakeLists.txt
+++ b/client/cpp/CMakeLists.txt
@@ -380,6 +380,11 @@ add_executable(cpp_client_unit_tests
     tests/CppClientIntegrationTests.cpp
 )
 
+include(CTest)
+if(BUILD_TESTING AND CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+    add_test(NAME cpp_client_mocked_unit_tests COMMAND cpp_client_mocked_unit_tests)
+endif()
+
 target_link_libraries(hello_drone
     PRIVATE
         ProjectAirsimClient

--- a/client/cpp/ProjectAirsimClientLib/src/AsyncResultInternal.h
+++ b/client/cpp/ProjectAirsimClientLib/src/AsyncResultInternal.h
@@ -5,6 +5,7 @@
 
 #pragma once
 #include <ProjectAirSimMessage/response_message.hpp>
+#include <atomic>
 #include <condition_variable>
 #include <mutex>
 
@@ -34,7 +35,11 @@ template <typename TAncestor>
 class TAsyncResultProviderBase : public TRefCounted<TAncestor> {
  public:
   TAsyncResultProviderBase(void)
-      : cv_done_(), fis_done_(false), mutex_(), status_(Status::InProgress) {}
+      : cv_done_(),
+        fis_canceled_(false),
+        fis_done_(false),
+        mutex_(),
+        status_(Status::InProgress) {}
 
   // Returns whether the task has been requested to cancel the operation
   bool FIsCanceled(void) const { return (fis_canceled_); }
@@ -62,8 +67,9 @@ class TAsyncResultProviderBase : public TRefCounted<TAncestor> {
  protected:
   std::condition_variable
       cv_done_;        // Conditional variable to set when task completes
-  bool fis_canceled_;  // If true, the task is requested to cancel the operation
-  bool fis_done_;      // If true, the task is complete
+  std::atomic_bool
+      fis_canceled_;  // If true, the task is requested to cancel the operation
+  std::atomic_bool fis_done_;  // If true, the task is complete
   std::mutex mutex_;   // Access guard to this object
   Status status_;      // The task return status
 };                     // class TAsyncResultProviderBase

--- a/client/cpp/ProjectAirsimClientLib/src/Client.cpp
+++ b/client/cpp/ProjectAirsimClientLib/src/Client.cpp
@@ -7,6 +7,7 @@
 
 #include <ProjectAirSimMessage/request_message.hpp>
 #include <ProjectAirSimMessage/response_message.hpp>
+#include <atomic>
 #include <chrono>
 #include <sstream>
 #include <string>
@@ -304,8 +305,9 @@ class Client::Impl {
   std::unique_ptr<std::thread> pthread_receiving_;  // Response receiving thread
   std::unique_ptr<std::thread> pthread_sending_;    // Request sending thread
   RequestID request_id_next_;                       // Next service request ID
-  bool run_request_threads_;  // If true, the sending & receiving threads should
-                              // keep running
+  std::atomic_bool
+      run_request_threads_;  // If true, the sending & receiving threads should
+                             // keep running
   internal::Topics topics_;   // Topic handler
   UMStrVecPSubscriptionToken
       um_str_vecpsubscription_token_;  // Mapping from topic name to

--- a/client/cpp/ProjectAirsimClientLib/src/Topics.h
+++ b/client/cpp/ProjectAirsimClientLib/src/Topics.h
@@ -4,6 +4,7 @@
 // MIT License. All rights reserved.
 
 #pragma once
+#include <atomic>
 #include <condition_variable>
 #include <functional>
 #include <memory>
@@ -137,7 +138,8 @@ class Topics {
  protected:
   std::condition_variable
       cv_topic_info_;  // Condition variable for topic_info_is_received_
-  bool fis_running_;  // If true, we're receiving topic messages from the server
+  std::atomic_bool
+      fis_running_;  // If true, we're receiving topic messages from the server
   bool ftopic_info_is_received_;  // If true, the topic list has been received
   std::mutex mutex_topic_info_;   // Access guard to topic_info_is_received
   std::mutex mutex_um_topic_;     // Access guard to um_str_topic_entry

--- a/client/cpp/README.md
+++ b/client/cpp/README.md
@@ -47,45 +47,47 @@ All public types live in the `microsoft::projectairsim::client` namespace (alias
 ### Prerequisites
 
 - CMake ≥ 3.20
-- C++17 compiler (GCC ≥ 10 or Clang ≥ 13)
+- C++17 compiler (GCC ≥ 10, Clang ≥ 13, or MSVC from Visual Studio 2022 Build Tools)
+- Ninja (installed by `setup_linux_dev_tools.sh` on Linux; must be available on `PATH` on Windows)
 - Internet access on first build (FetchContent downloads NNG, nlohmann-json, msgpack, optionally Eigen3)
 
 System Eigen3 is used if available (`sudo apt install libeigen3-dev`), otherwise it is fetched automatically.
 
-### Via `build.sh` (recommended)
+### Repository build wrapper (recommended)
 
-The C++ client is built automatically as part of the simulation library build steps:
+Build the C++ client independently of the simulation libraries:
 
 ```bash
-# Debug build (sim libs + C++ client)
-./build.sh simlibs_debug
+# Debug build (default)
+./build_cpp_client.sh debug
 
-# Release build (sim libs + C++ client)
-./build.sh simlibs_release
+# Release build
+./build_cpp_client.sh release
 
-# C++ client only (skips sim libs)
-./build.sh cpp_client_debug
-./build.sh cpp_client_release
+# Build and run mocked unit tests (does not require a simulator)
+./build_cpp_client.sh debug --tests
 ```
 
 Binaries are placed in:
 - `client/cpp/build_linux/Debug/hello_drone`
 - `client/cpp/build_linux/Release/hello_drone`
 
-### Via `build.cmd` on Windows
+### On Windows
 
-Windows builds reuse the existing `ProjectAirsimClientLib` and `HelloDrone` solution artifacts:
+The Windows wrapper uses an initialized MSVC environment when one is already
+available. Otherwise, it initializes MSVC from Visual Studio 2022 Build Tools
+and then builds the standalone CMake project. The Visual Studio IDE is not
+required.
 
 ```bat
-build.cmd cpp_client_debug
-build.cmd cpp_client_release
+build_cpp_client.cmd debug
+build_cpp_client.cmd release
+build_cpp_client.cmd debug --tests
 ```
 
-Outputs are placed in the existing project locations:
-- `client/cpp/libraries/x64/Debug`
-- `client/cpp/libraries/x64/Release`
-- `client/cpp/example_user_apps/HelloDrone/x64/Debug`
-- `client/cpp/example_user_apps/HelloDrone/x64/Release`
+Outputs are placed in:
+- `client/cpp/build_windows/Debug`
+- `client/cpp/build_windows/Release`
 
 ### Manual CMake build
 
@@ -104,9 +106,6 @@ cmake --build build_linux/Release -j$(nproc)
 ### Cleaning
 
 ```bash
-# Via build.sh (also cleans sim libs)
-./build.sh clean
-
 # Manual
 rm -rf client/cpp/build_linux
 ```
@@ -186,7 +185,7 @@ add_executable(my_app main.cpp)
 target_link_libraries(my_app PRIVATE ProjectAirsimClient pthread)
 ```
 
-> **Tip**: The simplest approach is to add your source files directly to `client/cpp/CMakeLists.txt` alongside `hello_drone` and rebuild via `build.sh cpp_client_debug`.
+> **Tip**: The simplest approach is to add your source files directly to `client/cpp/CMakeLists.txt` alongside `hello_drone` and rebuild via `./build_cpp_client.sh debug`.
 
 ### 2. Minimal app skeleton
 

--- a/client/cpp/tests/CppClientUnitTests.cpp
+++ b/client/cpp/tests/CppClientUnitTests.cpp
@@ -3,10 +3,12 @@
 #include <ProjectAirSimMessage/response_message.hpp>
 
 #include <chrono>
+#include <cstring>
 #include <functional>
 #include <iostream>
 #include <map>
 #include <memory>
+#include <new>
 #include <string>
 #include <thread>
 #include <vector>
@@ -14,6 +16,7 @@
 #include "msgpack.hpp"
 
 #include "FakeNNGI.h"
+#include "src/AsyncResultInternal.h"
 
 namespace asc = microsoft::projectairsim::client;
 namespace pas = microsoft::projectairsim;
@@ -28,6 +31,20 @@ bool Expect(bool condition, const std::string& message) {
     return false;
   }
   return true;
+}
+
+bool TestAsyncResultStartsNotCanceled() {
+  using Provider = asc::internal::TAsyncResultProvider<asc::Message>;
+
+  void* storage = ::operator new(sizeof(Provider));
+  std::memset(storage, 0xff, sizeof(Provider));
+  auto* provider = new (storage) Provider();
+
+  const bool starts_not_canceled = !provider->FIsCanceled();
+  provider->Release();
+
+  return Expect(starts_not_canceled,
+                "Async result provider should start not canceled");
 }
 
 std::string SuccessResponse(int id, const json& result) {
@@ -1532,6 +1549,7 @@ bool TestStaticSensorActorAPIsUseExpectedServiceMethods() {
 int main() {
   int failed = 0;
 
+  failed += TestAsyncResultStartsNotCanceled() ? 0 : 1;
   failed += TestRequestBeforeConnectFails() ? 0 : 1;
   failed += TestConnectAndRequest() ? 0 : 1;
   failed += TestGetBuildCommitHashUsesExpectedServiceMethod() ? 0 : 1;

--- a/docs/client_setup.md
+++ b/docs/client_setup.md
@@ -176,15 +176,17 @@ simulation server:
 Build the C++ client from the repository root:
 
 ```bash
-./build.sh cpp_client_debug
-./build.sh cpp_client_release
+./build_cpp_client.sh debug
+./build_cpp_client.sh release
+./build_cpp_client.sh debug --tests
 ```
 
 On Windows:
 
 ```bat
-build.cmd cpp_client_debug
-build.cmd cpp_client_release
+build_cpp_client.cmd debug
+build_cpp_client.cmd release
+build_cpp_client.cmd debug --tests
 ```
 
 Compiled Linux libraries and example binaries are placed in:
@@ -194,11 +196,11 @@ client/cpp/build_linux/Debug/
 client/cpp/build_linux/Release/
 ```
 
-Windows library artifacts are placed in:
+Windows build artifacts are placed in:
 
 ```text
-client\cpp\libraries\x64\Debug\
-client\cpp\libraries\x64\Release\
+client\cpp\build_windows\Debug\
+client\cpp\build_windows\Release\
 ```
 
 For setup details, binary locations, and usage examples, see

--- a/docs/cpp_client.md
+++ b/docs/cpp_client.md
@@ -46,8 +46,10 @@ To build the C++ client, install:
 
 - CMake 3.20 or newer
 - A C++17 compiler
-- Ninja on Linux, when using the repository `build.sh` targets
-- Visual Studio 2022 C++ build tools on Windows, when using `build.cmd`
+- Ninja when using the repository build wrapper. It is installed by
+  `setup_linux_dev_tools.sh` on Linux and must be available on `PATH` on Windows.
+- The MSVC C++ toolchain from Visual Studio 2022 Build Tools on Windows. The
+  Visual Studio IDE is not required.
 
 The Linux CMake build fetches third-party dependencies such as NNG,
 `nlohmann-json`, and msgpack on first configure. Eigen3 is used from the system
@@ -58,15 +60,11 @@ when available, or fetched automatically.
 From the repository root, build the C++ client with:
 
 ```bash
-./build.sh cpp_client_debug
-./build.sh cpp_client_release
-```
+./build_cpp_client.sh debug
+./build_cpp_client.sh release
 
-The C++ client is also built as part of the simulation library targets:
-
-```bash
-./build.sh simlibs_debug
-./build.sh simlibs_release
+# Build and run the mocked unit tests (no simulator required)
+./build_cpp_client.sh debug --tests
 ```
 
 Build outputs are placed under:
@@ -104,27 +102,20 @@ cmake --build client/cpp/build_linux/Debug -j$(nproc)
 From a Windows command prompt, use the repository build wrapper:
 
 ```bat
-build.cmd cpp_client_debug
-build.cmd cpp_client_release
+build_cpp_client.cmd debug
+build_cpp_client.cmd release
+build_cpp_client.cmd debug --tests
 ```
 
-The Windows Visual Studio projects place C++ client library artifacts under:
+Build artifacts are placed under:
 
 ```text
-client\cpp\libraries\x64\Debug\
-client\cpp\libraries\x64\Release\
+client\cpp\build_windows\Debug\
+client\cpp\build_windows\Release\
 ```
 
-The `HelloDrone` example executable is placed under:
-
-```text
-client\cpp\example_user_apps\HelloDrone\x64\Debug\
-client\cpp\example_user_apps\HelloDrone\x64\Release\
-```
-
-When running `hello_drone.exe`, make sure the corresponding
-`client\cpp\libraries\x64\<Configuration>\` directory is on `PATH`, or copy the
-required DLLs next to the executable.
+The client links statically; no client DLL directory needs to be added to
+`PATH` for `hello_drone.exe`.
 
 ## Running HelloDrone
 
@@ -146,7 +137,7 @@ On Linux:
 On Windows:
 
 ```bat
-client\cpp\example_user_apps\HelloDrone\x64\Debug\hello_drone.exe ^
+client\cpp\build_windows\Debug\hello_drone.exe ^
   --simhost 127.0.0.1 ^
   --simconfig client\python\example_user_scripts\sim_config
 ```

--- a/docs/development/use_source.md
+++ b/docs/development/use_source.md
@@ -55,7 +55,7 @@ Choose your development tool:
 - **[VS Code (Windows/Linux)](#vs-code-windows-linux)**
 - **[Visual Studio 2019 (Windows only)](#visual-studio-2019-windows-only)**
 
-**Note:** Project AirSim sim libs uses CMake which saves build configuration information in a cache, so **if you switch tools** between using command line, VS Code, or Visual Studio 2019 to drive the CMake project in the same folder, you should **clear the cache** by running `build clean` so the next tool can reset the configuration and build again properly.
+**Note:** Project AirSim sim libs uses CMake which saves build configuration information in a cache, so **if you switch tools** between using command line, VS Code, or Visual Studio 2019 to drive the CMake project in the same folder, you should **clear the cache** by running `build clean` so the next tool can reset the configuration and build again properly. The standalone C++ client uses its own build directories under `client/cpp/`.
 
 ---
 
@@ -77,15 +77,12 @@ On Linux, run the `build.sh` shell script.
 
 ```
 all = Clean + Build + Test + Package everything
-clean = Clean sim libs, C++ client + Blocks build files
+clean = Clean sim libs + Blocks build files
 
-simlibs_debug = Build + Package sim libs for Debug
-simlibs_release = Build + Package sim libs for Release
+simlibs_debug = Build sim libs for Debug
+simlibs_release = Build sim libs for Release
 test_simlibs_debug = Test sim libs for Debug
 test_simlibs_release = Test sim libs for Release
-
-cpp_client_debug = Build C++ client artifacts for Debug
-cpp_client_release = Build C++ client artifacts for Release
 
 blocks_debuggame = Build Plugin + Blocks for DebugGame (uses Debug sim libs)
 blocks_development = Build Plugin + Blocks for Development (uses Release sim libs)
@@ -95,7 +92,10 @@ package_blocks_debuggame = Package stand-alone Blocks environment executable for
 package_blocks_development = Package stand-alone Blocks environment executable for Development
 ```
 
-On Windows, the C++ client build reuses the existing ProjectAirsimClientLib and HelloDrone solution artifacts under `client/cpp/`.
+Build the C++ client separately, without SimLibs, with `build_cpp_client.sh` on
+Linux or `build_cpp_client.cmd` on Windows. Both wrappers accept `debug` or
+`release`, and `--tests` runs the mocked unit tests that do not require a
+running simulator.
 
 The sim lib components and unit test executables are built in the `projectairsim/build/` folder using CMake, and are automatically copied to the Unreal Blocks environment folder to be ready for building the plugin.
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
Squashes the work from internal PR #37 into the public repository.

This PR:
- Adds standalone Linux and Windows build wrappers for the C++ client, independent of SimLibs.
- Moves mocked C++ client unit-test execution into the standalone CMake/CTest flow.
- Updates the C++ client CI workflow to use the new wrappers and trigger on their changes.
- Updates C++ client, setup, and development documentation.
- Fixes C++ client synchronization and topic/API details included in the source work.

## How Has This Been Tested?
- git diff --check passed.
- The local C++ build could not be executed because this environment does not have bash, cmake, or ninja installed.
- CI is configured to build the client and run the mocked unit tests on Linux and Windows.

## Screenshots and videos (if appropriate):
Not applicable.