### PR TITLE
fix ros2 depth image conversion from float16 to float32

### DIFF
--- a/ros/projectairsim_ros2_cpp/include/projectairsim_ros2_cpp/ros2_conversion_utils.hpp
+++ b/ros/projectairsim_ros2_cpp/include/projectairsim_ros2_cpp/ros2_conversion_utils.hpp
@@ -593,33 +593,79 @@ inline bool PopulateImagePayloadFromMsgpack(const std::string& payload,
     throw std::runtime_error("Image payload is missing required fields");
   }
 
-  std::size_t bytes_per_pixel = 0;
+  std::size_t source_bytes_per_pixel = 0;
+  std::size_t output_bytes_per_pixel = 0;
+  bool convert_half_depth = false;
   if (parsed_metadata.source_encoding == "BGR") {
     image->encoding = "bgr8";
-    bytes_per_pixel = 3;
+    source_bytes_per_pixel = 3;
+    output_bytes_per_pixel = 3;
   } else if (parsed_metadata.source_encoding == "16UC1") {
     image->encoding = "mono16";
-    bytes_per_pixel = 2;
+    source_bytes_per_pixel = 2;
+    output_bytes_per_pixel = 2;
+  } else if (parsed_metadata.source_encoding == "16FC1") {
+    image->encoding = "32FC1";
+    source_bytes_per_pixel = 2;
+    output_bytes_per_pixel = 4;
+    convert_half_depth = true;
   } else {
     if (metadata != nullptr) *metadata = std::move(parsed_metadata);
     return false;
   }
 
-  const std::size_t row_bytes =
-      static_cast<std::size_t>(image->width) * bytes_per_pixel;
-  if (row_bytes > std::numeric_limits<std::uint32_t>::max()) {
+  const std::size_t source_row_bytes =
+      static_cast<std::size_t>(image->width) * source_bytes_per_pixel;
+  const std::size_t output_row_bytes =
+      static_cast<std::size_t>(image->width) * output_bytes_per_pixel;
+  if (output_row_bytes > std::numeric_limits<std::uint32_t>::max()) {
     throw std::runtime_error("Image row size exceeds uint32 range");
   }
   if (image->height != 0 &&
-      row_bytes > std::numeric_limits<std::size_t>::max() / image->height) {
+      source_row_bytes >
+          std::numeric_limits<std::size_t>::max() / image->height) {
     throw std::runtime_error("Image dimensions overflow payload size");
   }
-  const std::size_t expected_min_bytes = row_bytes * image->height;
+  const std::size_t expected_min_bytes = source_row_bytes * image->height;
   if (data_size < expected_min_bytes) {
     throw std::runtime_error("Image payload is smaller than step*height");
   }
 
-  image->step = static_cast<std::uint32_t>(row_bytes);
+  image->step = static_cast<std::uint32_t>(output_row_bytes);
+  if (convert_half_depth) {
+    if ((data_size % 2) != 0) {
+      throw std::runtime_error("16FC1 image payload has an odd byte count");
+    }
+    const std::size_t pixel_count = data_size / 2;
+    if (pixel_count > std::numeric_limits<std::size_t>::max() / 4) {
+      throw std::runtime_error("Converted image payload size overflows");
+    }
+    image->data.resize(pixel_count * 4);
+    const auto source_byte = [&](std::size_t index) {
+      if (!data_is_array) {
+        return static_cast<std::uint8_t>(data[index]);
+      }
+      const auto byte =
+          detail::ImageUnsigned(data_array->via.array.ptr[index], "data[]");
+      if (byte > std::numeric_limits<std::uint8_t>::max()) {
+        throw std::runtime_error("Image data byte exceeds uint8 range");
+      }
+      return static_cast<std::uint8_t>(byte);
+    };
+    for (std::size_t i = 0; i < pixel_count; ++i) {
+      const std::uint16_t bits =
+          static_cast<std::uint16_t>(source_byte(i * 2)) |
+          (static_cast<std::uint16_t>(source_byte(i * 2 + 1)) << 8);
+      const float meters = HalfBitsToFloat(bits);
+      const float ros_depth =
+          std::isfinite(meters) ? meters
+                                : std::numeric_limits<float>::quiet_NaN();
+      std::memcpy(image->data.data() + i * 4, &ros_depth, sizeof(ros_depth));
+    }
+    if (metadata != nullptr) *metadata = std::move(parsed_metadata);
+    return true;
+  }
+
   image->data.resize(data_size);
   if (data_is_array) {
     for (std::size_t i = 0; i < data_size; ++i) {

--- a/ros/projectairsim_ros2_cpp/test/ros2_conversion_utils_test.cpp
+++ b/ros/projectairsim_ros2_cpp/test/ros2_conversion_utils_test.cpp
@@ -3,7 +3,9 @@
 #include <gtest/gtest.h>
 
 #include <array>
+#include <cmath>
 #include <cstdint>
+#include <cstring>
 #include <map>
 #include <stdexcept>
 #include <string>
@@ -200,6 +202,25 @@ TEST(Ros2ConversionUtils, NativeDepthImagePayloadIsConverted) {
   EXPECT_EQ(image.encoding, "mono16");
   EXPECT_EQ(image.step, 4U);
   EXPECT_EQ(image.data, pixels);
+}
+
+TEST(Ros2ConversionUtils, NativeHalfDepthImagePayloadIsConvertedToFloat) {
+  // IEEE 754 binary16 little-endian: 1.0 and +inf.
+  const std::vector<std::uint8_t> pixels{0x00, 0x3C, 0x00, 0x7C};
+  sensor_msgs::msg::Image image;
+  bridge::NativeImageMetadata metadata;
+
+  ASSERT_TRUE(bridge::PopulateImagePayloadFromMsgpack(
+      PackNativeImage("16FC1", 2, 1, pixels), &image, &metadata));
+  EXPECT_EQ(image.encoding, "32FC1");
+  EXPECT_EQ(image.step, 8U);
+  ASSERT_EQ(image.data.size(), 8U);
+
+  std::array<float, 2> depth{};
+  std::memcpy(depth.data(), image.data.data(), image.data.size());
+  EXPECT_FLOAT_EQ(depth[0], 1.0F);
+  EXPECT_TRUE(std::isnan(depth[1]));
+  EXPECT_EQ(metadata.source_encoding, "16FC1");
 }
 
 TEST(Ros2ConversionUtils, NativeImagePayloadRejectsInvalidInputs) {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->
This pull request adds support for converting 16-bit floating point depth images (with encoding `16FC1`) to 32-bit floating point images (`32FC1`) in the `PopulateImagePayloadFromMsgpack` function. It also includes a new unit test to verify this functionality and makes minor test includes updates.

### Image conversion enhancements:
* Updated `PopulateImagePayloadFromMsgpack` in `ros2_conversion_utils.hpp` to handle `16FC1` input by converting half-precision (16-bit) float depth images to single-precision (32-bit) float images, including proper memory allocation, byte handling, and NaN handling for non-finite values.

### Testing improvements:
* Added a new test `NativeHalfDepthImagePayloadIsConvertedToFloat` in `ros2_conversion_utils_test.cpp` to verify correct conversion from 16-bit half-precision to 32-bit float images, including checks for value conversion and NaN propagation.
* Updated includes in `ros2_conversion_utils_test.cpp` to add `<cmath>` and `<cstring>` for math and memory operations needed by the new test.

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->
locally tested win+wsl2 echoing depth topic

## Screenshots and videos (if appropriate):